### PR TITLE
Add reference modules to documentation

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,3 @@
+# CLI
+
+::: dbt_score.cli

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -1,0 +1,3 @@
+# Exceptions
+
+::: dbt_score.exceptions

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,3 @@
+# Models
+
+::: dbt_score.models

--- a/docs/reference/rule.md
+++ b/docs/reference/rule.md
@@ -1,0 +1,3 @@
+# Rule
+
+::: dbt_score.rule

--- a/docs/reference/rule_registry.md
+++ b/docs/reference/rule_registry.md
@@ -1,0 +1,3 @@
+# Rule registry
+
+::: dbt_score.rule_registry

--- a/docs/reference/rules/generic.md
+++ b/docs/reference/rules/generic.md
@@ -1,0 +1,3 @@
+# Generic
+
+::: dbt_score.rules.generic

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,11 @@ plugins:
   - mkdocstrings
 nav:
   - Home: index.md
+  - Reference:
+      - reference/cli.md
+      - reference/exceptions.md
+      - reference/models.md
+      - reference/rule.md
+      - Rules:
+          - reference/rules/generic.md
+      - reference/rule_registry.md


### PR DESCRIPTION
`mkdocs` picks up docstrings in Python modules to generate HTML documentation.
Add all existing modules to the index.