### PR TITLE
Prevent Rule from being discovered by rule registry

### DIFF
--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -1,3 +1,3 @@
-# CLI
+# Scoring
 
 ::: dbt_score.scoring

--- a/src/dbt_score/rule_registry.py
+++ b/src/dbt_score/rule_registry.py
@@ -49,7 +49,7 @@ class RuleRegistry:
             module = importlib.import_module(module_name)
             for obj_name in dir(module):
                 obj = module.__dict__[obj_name]
-                if type(obj) is type and issubclass(obj, Rule):
+                if type(obj) is type and issubclass(obj, Rule) and obj is not Rule:
                     self._add_rule(obj_name, obj)
 
     def _add_rule(self, name: str, rule: Type[Rule]) -> None:


### PR DESCRIPTION
- Prevent `Rule` from being added to the set of rules.
- At the same time, fix a small documentation typo.