### PR TITLE
Add dbt-score entry point in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 
+[project.scripts]
+dbt-score = "dbt_score.cli:cli"
+
 [tool.pdm]
 [tool.pdm.dev-dependencies]
 dev = [

--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -20,7 +20,11 @@ BANNER: Final[str] = r"""
 
 
 @click.version_option(message="%(version)s")
-@click.group(help=f"\b{BANNER}", invoke_without_command=False)
+@click.group(
+    help=f"\b{BANNER}",
+    invoke_without_command=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 def cli() -> None:
     """CLI entrypoint."""
 


### PR DESCRIPTION
To ensure that `dbt-score` becomes an executable in any environment where it's installed.
Keep pdm's entry point too, to be able to `pdm run dbt-score` in local development environments.

While there, add the option to use `-h` to get help.