### PR TITLE
Enable deploying to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
+
 on:
   push:
     tags:
       - "*"
+
 jobs:
   release:
     name: release
@@ -10,6 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up PDM


### PR DESCRIPTION
Deploying dbt-score to PyPI via github actions when the project is tagged.

- https://pypi.org/project/dbt-score/#history
