### PR TITLE
Limit output length of rule generic.columns_have_description

### DIFF
--- a/src/dbt_score/rules/generic.py
+++ b/src/dbt_score/rules/generic.py
@@ -21,7 +21,7 @@ def columns_have_description(model: Model) -> RuleViolation | None:
         message = f"Columns lack a description: {', '.join(invalid_column_names)}."
         if len(message) > max_length:
             message = f"{message[:60]}…"
-        return RuleViolation(message=message[:90])
+        return RuleViolation(message=message)
 
 
 @rule


### PR DESCRIPTION
Long (multiline) output can be hard to read.