### PR TITLE
Fix model selection when no models are specified

### DIFF
--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -248,7 +248,7 @@ class ManifestLoader:
         self._reindex_tests()
         self._load_models()
 
-        if select is not None:
+        if select:
             self._select_models(select)
 
         if len(self.models) == 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,9 @@ def test_lint_existing_manifest(manifest_path):
     with patch("dbt_score.cli.Config._load_toml_file"):
         runner = CliRunner()
         result = runner.invoke(lint, ["--manifest", manifest_path])
+
+        assert "model1" in result.output
+        assert "model2" in result.output
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
Fix the issue where no models are linted when no `--select` is provided.

At the same time, add a test that checks this behavior.