### PR TITLE
Fix path in rule discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ below:
 [tool.dbt-score]
 rule_namespaces = ["dbt_score.rules", "dbt_score_rules", "custom_rules"]
 disabled_rules = ["dbt_score.rules.generic.columns_have_description"]
+inject_cwd_in_python_path = true
 
 [tool.dbt-score.badges]
 first.threshold = 10.0

--- a/docs/create_rules.md
+++ b/docs/create_rules.md
@@ -62,7 +62,8 @@ By default `dbt-score` will look for rules in the Python namespace
 `dbt_score_rules`. Rules can be stored anywhere in the Python path under the
 `dbt_score_rules` namespace. In many cases, having such a folder in the dbt
 project from where you invoke dbt and dbt-score will work. In this folder, all
-rules defined in `.py` files will be automatically discovered.
+rules defined in `.py` files will be automatically discovered. By default, the
+current working directory is injected in the Python path.
 
 If nested folders are used, e.g. `dbt_score_rules/generic_rules/rules.py`, an
 `__init__.py` file needs to be present in the nested folder to make it

--- a/src/dbt_score/config.py
+++ b/src/dbt_score/config.py
@@ -49,6 +49,7 @@ class Config:
     _options: Final[list[str]] = [
         "rule_namespaces",
         "disabled_rules",
+        "inject_cwd_in_python_path",
     ]
     _rules_section: Final[str] = "rules"
     _badges_section: Final[str] = "badges"
@@ -57,6 +58,7 @@ class Config:
         """Initialize the Config object."""
         self.rule_namespaces: list[str] = ["dbt_score.rules", "dbt_score_rules"]
         self.disabled_rules: list[str] = []
+        self.inject_cwd_in_python_path = True
         self.rules_config: dict[str, RuleConfig] = {}
         self.config_file: Path | None = None
         self.badge_config: BadgeConfig = BadgeConfig()

--- a/src/dbt_score/rule_registry.py
+++ b/src/dbt_score/rule_registry.py
@@ -26,7 +26,7 @@ class RuleRegistry:
         self._rules: dict[str, Rule] = {}
 
         # Add cwd to Python path to load custom rules
-        if config.inject_cwd_in_python_path:
+        if config.inject_cwd_in_python_path and os.getcwd() not in sys.path:
             sys.path.append(os.getcwd())
 
     @property

--- a/src/dbt_score/rule_registry.py
+++ b/src/dbt_score/rule_registry.py
@@ -25,10 +25,6 @@ class RuleRegistry:
         self.config = config
         self._rules: dict[str, Rule] = {}
 
-        # Add cwd to Python path to load custom rules
-        if config.inject_cwd_in_python_path and os.getcwd() not in sys.path:
-            sys.path.append(os.getcwd())
-
     @property
     def rules(self) -> dict[str, Rule]:
         """Get all rules."""
@@ -73,5 +69,13 @@ class RuleRegistry:
 
     def load_all(self) -> None:
         """Load all rules, core and third-party."""
+        # Add cwd to Python path
+        old_sys_path = sys.path  # Save original values
+        if self.config.inject_cwd_in_python_path and os.getcwd() not in sys.path:
+            sys.path.append(os.getcwd())
+
         for namespace in self.config.rule_namespaces:
             self._load(namespace)
+
+        # Restore original values
+        sys.path = old_sys_path

--- a/src/dbt_score/rule_registry.py
+++ b/src/dbt_score/rule_registry.py
@@ -5,7 +5,9 @@ This module implements rule discovery.
 
 import importlib
 import logging
+import os
 import pkgutil
+import sys
 from typing import Iterator, Type
 
 from dbt_score.config import Config
@@ -22,6 +24,10 @@ class RuleRegistry:
         """Instantiate a rule registry."""
         self.config = config
         self._rules: dict[str, Rule] = {}
+
+        # Add cwd to Python path to load custom rules
+        if config.inject_cwd_in_python_path:
+            sys.path.append(os.getcwd())
 
     @property
     def rules(self) -> dict[str, Rule]:


### PR DESCRIPTION
By default, inject the current working directory into the python path.

This ensures that rules can be discovered properly when running `dbt-score` from CLI. When `dbt-score` is invoked by running .e.g `python -m dbt_score`, the path is added already. Running `dbt-score` however, did not include the path.