### PR TITLE
Lint the current dbt project only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Lint the current dbt project only, not including the imported models.
+
 ## [0.1.3] - 2023-06-11
 
 - Inject current working directory into python path by default.

--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -54,7 +54,7 @@ def cli() -> None:
 @click.option(
     "--namespace",
     "-n",
-    help="Namespace.",
+    help="Namespace to look for rules.",
     default=None,
     multiple=True,
 )

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -241,7 +241,12 @@ class ManifestLoader:
             select: An optional dbt selection.
         """
         self.raw_manifest = json.loads(file_path.read_text(encoding="utf-8"))
-        self.raw_nodes = self.raw_manifest.get("nodes", {})
+        self.project_name = self.raw_manifest["metadata"]["project_name"]
+        self.raw_nodes = {
+            node_id: node_values
+            for node_id, node_values in self.raw_manifest.get("nodes", {}).items()
+            if node_values["package_name"] == self.project_name
+        }
         self.models: list[Model] = []
         self.tests: dict[str, list[dict[str, Any]]] = defaultdict(list)
 

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -90,7 +90,7 @@
       "database": "db",
       "schema": "schema",
       "raw_code": "SELECT x FROM y",
-      "alias": "model2_alias",
+      "alias": "model1_alias",
       "patch_path": "/path/to/model1.yml",
       "tags": [],
       "depends_on": {},

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -1,7 +1,11 @@
 {
+  "metadata": {
+    "project_name": "package"
+  },
   "nodes": {
     "analysis.package.analysis1": {
-      "resource_type": "analysis"
+      "resource_type": "analysis",
+      "package_name": "package"
     },
     "model.package.model1": {
       "resource_type": "model",
@@ -63,6 +67,36 @@
       "language": "sql",
       "access": "public"
     },
+    "model.package2.model1": {
+      "resource_type": "model",
+      "unique_id": "model.package2.model1",
+      "name": "model1",
+      "relation_name": "database.schema.model1",
+      "description": "A great model.\nExample use:\n```sql\nselect 1;\n```",
+      "original_file_path": "/path/to/model1.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "package_name": "package2",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT x FROM y",
+      "alias": "model2_alias",
+      "patch_path": "/path/to/model1.yml",
+      "tags": [],
+      "depends_on": {},
+      "language": "sql",
+      "access": "public"
+    },
     "test.package.test1": {
       "resource_type": "test",
       "attached_node": "model.package.model1",
@@ -73,6 +107,7 @@
           "column_name": "a"
         }
       },
+      "package_name": "package",
       "tags": []
     },
     "test.package.test2": {
@@ -83,10 +118,12 @@
         "name": "type",
         "kwargs": {}
       },
+      "package_name": "package",
       "tags": []
     },
     "test.package.test3": {
-      "resource_type": "test"
+      "resource_type": "test",
+      "package_name": "package"
     }
   }
 }

--- a/tests/resources/manifest_empty.json
+++ b/tests/resources/manifest_empty.json
@@ -1,3 +1,6 @@
 {
+  "metadata": {
+    "project_name": "package"
+  },
   "nodes": {}
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ def test_manifest_load(mock_read_text, raw_manifest):
                 node
                 for node in raw_manifest["nodes"].values()
                 if node["resource_type"] == "model"
+                and node["package_name"] == raw_manifest["metadata"]["project_name"]
             ]
         )
         assert loader.models[0].tests[0].name == "test2"


### PR DESCRIPTION
Instead of linting all models that can be found in the manifest, just lint the models from the current project.

Linting models of packages should be done in the dbt projects of the packages itself.