### PR TITLE
Improve error handling in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **Breaking**: Improve error handling in CLI. Log messages are written in
+  stderr, and exit code is 2 in case of anything going wrong. (#73)
+
 ## [0.5.0] - 2024-08-15
 
 - Add model filters to let models be ignored by certain rules.

--- a/docs/programmatic_invocations.md
+++ b/docs/programmatic_invocations.md
@@ -1,0 +1,69 @@
+# Programmatic invocations
+
+`dbt-score` can be used interactively as a CLI tool, but also be integrated in
+Continuous Integration systems and anywhere else it makes sense.
+
+## Machine-readable output
+
+In order to programmatically use the output of `dbt-score` in another program,
+the JSON formatter can be used:
+
+```shell
+$ dbt-score lint --format json
+{
+  "models": {
+    "model1": {
+      "score": 8.666666666666668,
+      "badge": "🥈",
+      "pass": true,
+      "results": {
+        "dbt_score.rules.generic.columns_have_description": {
+          "result": "OK",
+          "severity": "medium",
+          "message": null
+        },
+        "dbt_score.rules.generic.has_description": {
+          "result": "OK",
+          "severity": "medium",
+          "message": null
+        },
+        "dbt_score.rules.generic.has_owner": {
+          "result": "WARN",
+          "severity": "medium",
+          "message": "Model lacks an owner."
+        },
+        "dbt_score.rules.generic.public_model_has_example_sql": {
+          "result": "OK",
+          "severity": "low",
+          "message": null
+        },
+        "dbt_score.rules.generic.sql_has_reasonable_number_of_lines": {
+          "result": "OK",
+          "severity": "medium",
+          "message": null
+        }
+      }
+    }
+  },
+  "project": {
+    "score": 8.666666666666668,
+    "badge": "🥈",
+    "pass": true
+  }
+}
+```
+
+## Exit codes
+
+When `dbt-score` terminates, it exists with one of the following exit codes:
+
+- `0` in case of successful termination. This is the happy case, when the
+  project being linted either doesn't raise any warning, or the warnings are
+  small enough to be above the thresholds. This generally means "successful
+  linting".
+- `1` in case of linting errors. This is the unhappy case: some models in the
+  project raise enough warnings to have a score below the defined thresholds.
+  This generally means "linting doesn't pass".
+- `2` in case of an unexpected error. This happens for example if something is
+  misconfigured (for example a faulty dbt project), or the wrong parameters are
+  given to the CLI. This generally means "setup needs to be fixed".

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - Create rules: create_rules.md
   - Package rules: package_rules.md
   - Configuration: configuration.md
+  - Programmatic invocations: programmatic_invocations.md
   - Rules:
       - rules/generic.md
   - Reference:
@@ -41,5 +42,6 @@ nav:
           - reference/formatters/index.md
           - reference/formatters/human_readable_formatter.md
           - reference/formatters/manifest_formatter.md
+          - reference/formatters/json_formatter.md
   - Contributor's guide: contributing.md
   - Changelog: https://github.com/PicnicSupermarket/dbt-score/blob/master/CHANGELOG.md

--- a/src/dbt_score/__main__.py
+++ b/src/dbt_score/__main__.py
@@ -12,7 +12,7 @@ from dbt_score.cli import cli
 def set_logging() -> None:
     """Set logging configuration."""
     log_format = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
-    handler: logging.Handler = logging.StreamHandler(sys.stdout)
+    handler: logging.Handler = logging.StreamHandler(sys.stderr)
     logging.basicConfig(format=log_format, handlers=[handler])
     for handler in logging.getLogger().handlers:
         handler.setLevel(logging.WARNING)

--- a/src/dbt_score/formatters/json_formatter.py
+++ b/src/dbt_score/formatters/json_formatter.py
@@ -2,6 +2,7 @@
 
 Shape of the JSON output:
 
+```json
 {
     "models": {
         "model_foo": {
@@ -39,6 +40,7 @@ Shape of the JSON output:
         "pass": false
     }
 }
+```
 """
 
 

--- a/tests/formatters/test_json_formatter.py
+++ b/tests/formatters/test_json_formatter.py
@@ -26,7 +26,6 @@ def test_json_formatter(
     formatter.model_evaluated(model1, results, Score(10.0, "🥇"))
     formatter.project_evaluated(Score(10.0, "🥇"))
     stdout = capsys.readouterr().out
-    print()
     assert (
         stdout
         == """{


### PR DESCRIPTION
Improve error handling:
- If `dbt parse` fails to run, a nice(r) error message is displayed
- In case of any error, the return code is 2
- Logging is written to stderr, instead of stdout