### PR TITLE
Fix typo in documentation homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ encourage) good practices.
 > dbt-score lint
 🥇 customers (score: 10.0)
     OK   dbt_score.rules.generic.has_description
-    OK   dbt_score.rules.generic.has_owner: Model lacks an owner.
+    OK   dbt_score.rules.generic.has_owner
     OK   dbt_score.rules.generic.sql_has_reasonable_number_of_lines
 Score: 10.0 🥇
 ```


### PR DESCRIPTION
There shouldn't be any warning in this example.