### PR TITLE
Documenting support for python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Documenting support for python 3.13. (#86)
+
 ## [0.8.0] - 2024-11-12
 
 - Support linting of sources.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
 ]
@@ -118,4 +119,3 @@ fail_under = 80
 exclude_also = [
     "@overload"
 ]
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{310,311,312},lint,docs
+env_list = py{310,311,312,313},lint,docs
 
 skip_missing_interpreters = true
 


### PR DESCRIPTION
`dbt-score` is documented as working for Python 3.12, but it looks like it also supports Python 3.13, just that this is not documented. This PR documents this support.