### PR TITLE
Fix missing test metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [Unreleased]
 
 - Add debug mode to help writing new rules. (#91)
+- Fix tests without metadata. (#88)
 
 ## [0.9.0] - 2024-12-19
 

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -364,7 +364,7 @@ class Source(HasColumnsMixin):
             tests=[
                 Test.from_node(test)
                 for test in test_values
-                if not test.get("test_metadata", {})  # Not all tests have metadata.
+                if not test.get("test_metadata", {})
                 .get("kwargs", {})
                 .get("column_name")
             ],

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -63,8 +63,8 @@ class Test:
         """Create a test object from a test node in the manifest."""
         return cls(
             name=test_node["name"],
-            type=test_node["test_metadata"]["name"],
-            kwargs=test_node["test_metadata"].get("kwargs", {}),
+            type=test_node.get("test_metadata", {}).get("name", "generic"),
+            kwargs=test_node.get("test_metadata", {}).get("kwargs", {}),
             tags=test_node.get("tags", []),
             _raw_values=test_node,
         )
@@ -359,7 +359,9 @@ class Source(HasColumnsMixin):
             tests=[
                 Test.from_node(test)
                 for test in test_values
-                if not test["test_metadata"]["kwargs"].get("column_name")
+                if not test.get("test_metadata", {})  # Not all tests have metadata.
+                .get("kwargs", {})
+                .get("column_name")
             ],
             _raw_values=node_values,
             _raw_test_values=test_values,

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -435,20 +435,17 @@ class ManifestLoader:
         """Index tests based on their associated evaluable."""
         for node_values in self.raw_nodes.values():
             if node_values.get("resource_type") == "test":
-                # tests for models have a non-null value for `attached_node`
+                # Tests for models have a non-null value for `attached_node`
                 if attached_node := node_values.get("attached_node"):
                     self.tests[attached_node].append(node_values)
 
-                # Tests for sources will have a null `attached_node`,
-                # and a non-empty list for `sources`.
-                # They need to be attributed to the source id
+                # Tests for sources or separate tests will have `attached_node` == null.
+                # They need to be attributed to the node id
                 # based on the `depends_on` field.
-                elif node_values.get("sources") and (
-                    source_unique_id := next(
-                        iter(node_values.get("depends_on", {}).get("nodes", [])), None
-                    )
+                elif node_unique_id := next(
+                    iter(node_values.get("depends_on", {}).get("nodes", [])), None
                 ):
-                    self.tests[source_unique_id].append(node_values)
+                    self.tests[node_unique_id].append(node_values)
 
     def _filter_evaluables(self, select: Iterable[str]) -> None:
         """Filter evaluables like dbt's --select."""

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -141,7 +141,10 @@ class HasColumnsMixin:
                 [
                     test
                     for test in test_values
-                    if test["test_metadata"]["kwargs"].get("column_name") == name
+                    if test.get("test_metadata", {})
+                    .get("kwargs", {})
+                    .get("column_name")
+                    == name
                 ],
             )
             for name, values in node_values.get("columns", {}).items()
@@ -224,7 +227,9 @@ class Model(HasColumnsMixin):
             tests=[
                 Test.from_node(test)
                 for test in test_values
-                if not test["test_metadata"]["kwargs"].get("column_name")
+                if not test.get("test_metadata", {})
+                .get("kwargs", {})
+                .get("column_name")
             ],
             depends_on=node_values["depends_on"],
             _raw_values=node_values,

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -125,6 +125,13 @@
       "resource_type": "test",
       "package_name": "package"
     },
+    "test.package.test4": {
+      "resource_type": "test",
+      "depends_on": { "nodes": ["model.package.model1"] },
+      "name": "test4",
+      "package_name": "package",
+      "tags": []
+    },
     "test.package.source_test1": {
       "resource_type": "test",
       "package_name": "package",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,7 @@ def test_manifest_load(mock_read_text, raw_manifest):
             ]
         )
         assert loader.models[0].tests[0].name == "test2"
+        assert loader.models[0].tests[1].name == "test4"
         assert loader.models[0].columns[0].tests[0].name == "test1"
 
         assert len(loader.sources) == len(


### PR DESCRIPTION
Some tests, e.g. that are defined in separate .sql files, don't have `metadata` specified. dbt-score will break if a test like this is defined in a model or source.