### PR TITLE
Add generic rule: models should implement uniqueness test for their PK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 - Add debug mode to help writing new rules. (#91)
 - Fix tests without metadata. (#88)
 - Add new rule to enforce presence of uniqueness test. (#90)
+- Add `constraints` to the model schema. (#90)
 
 ## [0.9.0] - 2024-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
-this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -11,14 +12,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix tests without metadata. (#88)
 - Add new rule to enforce presence of uniqueness test. (#90)
 - Add new rule to enforce single-column PK to be defined at column level. (#90)
-- Add new rule to enforce 1 column uniqueness test to be defined at column level. (#90)
+- Add new rule to enforce 1 column uniqueness test to be defined at column
+  level. (#90)
 - Add `constraints` to the model schema. (#90)
 
 ## [0.9.0] - 2024-12-19
 
 - Documenting support for python 3.13. (#86)
-- Only show failing rules per default in `HumanReadableFormatter`. Also added `--show`
-  parameter in the CLI to change this behavior. (#77)
+- Only show failing rules per default in `HumanReadableFormatter`. Also added
+  `--show` parameter in the CLI to change this behavior. (#77)
 - Ignore imported rules and filters when building the rule registry. (#87)
 
 ## [0.8.0] - 2024-11-12
@@ -30,7 +32,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `@rule_filter` and `ModelFilter` becomes `RuleFilter`.
 - **Breaking**: Config option `model_filter_names` becomes `rule_filter_names`.
 - **Breaking**: CLI flag naming fixes: `--fail_any_model_under` becomes
-  `--fail-any-item-under` and `--fail_project_under` becomes `--fail-project-under`.
+  `--fail-any-item-under` and `--fail_project_under` becomes
+  `--fail-project-under`.
 
 ## [0.7.1] - 2024-11-01
 
@@ -40,14 +43,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Breaking**: The rule `public_model_has_example_sql` has been renamed
   `has_example_sql` and applies by default to all models.
-- **Breaking**: Remove `dbt-core` from dependencies. Since it is not mandatory for
-  `dbt-score` to execute `dbt`, remove the dependency.
+- **Breaking**: Remove `dbt-core` from dependencies. Since it is not mandatory
+  for `dbt-score` to execute `dbt`, remove the dependency.
 - **Breaking**: Stop using `MultiOption` selection type.
 
 ## [0.6.0] - 2024-08-23
 
-- **Breaking**: Improve error handling in CLI. Log messages are written in stderr, and
-  exit code is 2 in case of anything going wrong. (#73)
+- **Breaking**: Improve error handling in CLI. Log messages are written in
+  stderr, and exit code is 2 in case of anything going wrong. (#73)
 - Auto-round scores down to align scores and medals. (#74)
 
 ## [0.5.0] - 2024-08-15
@@ -56,8 +59,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.4.0] - 2024-08-08
 
-- Add null check before calling `project_evaluated` in the `evaluate` method to prevent
-  errors when no models are found. (#64)
+- Add null check before calling `project_evaluated` in the `evaluate` method to
+  prevent errors when no models are found. (#64)
 - Add JSON formatter for machine-readable output. (#68)
 
 ## [0.3.0] - 2024-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 - Add debug mode to help writing new rules. (#91)
 - Fix tests without metadata. (#88)
+- Add new rule to enforce presence of uniqueness test. (#90)
 
 ## [0.9.0] - 2024-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -12,15 +11,14 @@ and this project adheres to
 - Fix tests without metadata. (#88)
 - Add new rule to enforce presence of uniqueness test. (#90)
 - Add new rule to enforce single-column PK to be defined at column level. (#90)
-- Add new rule to enforce 1 column uniqueness test to be defined at column
-  level. (90)
+- Add new rule to enforce 1 column uniqueness test to be defined at column level. (#90)
 - Add `constraints` to the model schema. (#90)
 
 ## [0.9.0] - 2024-12-19
 
 - Documenting support for python 3.13. (#86)
-- Only show failing rules per default in `HumanReadableFormatter`. Also added
-  `--show` parameter in the CLI to change this behavior. (#77)
+- Only show failing rules per default in `HumanReadableFormatter`. Also added `--show`
+  parameter in the CLI to change this behavior. (#77)
 - Ignore imported rules and filters when building the rule registry. (#87)
 
 ## [0.8.0] - 2024-11-12
@@ -32,8 +30,7 @@ and this project adheres to
   `@rule_filter` and `ModelFilter` becomes `RuleFilter`.
 - **Breaking**: Config option `model_filter_names` becomes `rule_filter_names`.
 - **Breaking**: CLI flag naming fixes: `--fail_any_model_under` becomes
-  `--fail-any-item-under` and `--fail_project_under` becomes
-  `--fail-project-under`.
+  `--fail-any-item-under` and `--fail_project_under` becomes `--fail-project-under`.
 
 ## [0.7.1] - 2024-11-01
 
@@ -43,14 +40,14 @@ and this project adheres to
 
 - **Breaking**: The rule `public_model_has_example_sql` has been renamed
   `has_example_sql` and applies by default to all models.
-- **Breaking**: Remove `dbt-core` from dependencies. Since it is not mandatory
-  for `dbt-score` to execute `dbt`, remove the dependency.
+- **Breaking**: Remove `dbt-core` from dependencies. Since it is not mandatory for
+  `dbt-score` to execute `dbt`, remove the dependency.
 - **Breaking**: Stop using `MultiOption` selection type.
 
 ## [0.6.0] - 2024-08-23
 
-- **Breaking**: Improve error handling in CLI. Log messages are written in
-  stderr, and exit code is 2 in case of anything going wrong. (#73)
+- **Breaking**: Improve error handling in CLI. Log messages are written in stderr, and
+  exit code is 2 in case of anything going wrong. (#73)
 - Auto-round scores down to align scores and medals. (#74)
 
 ## [0.5.0] - 2024-08-15
@@ -59,8 +56,8 @@ and this project adheres to
 
 ## [0.4.0] - 2024-08-08
 
-- Add null check before calling `project_evaluated` in the `evaluate` method to
-  prevent errors when no models are found. (#64)
+- Add null check before calling `project_evaluated` in the `evaluate` method to prevent
+  errors when no models are found. (#64)
 - Add JSON formatter for machine-readable output. (#68)
 
 ## [0.3.0] - 2024-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to
 - Fix tests without metadata. (#88)
 - Add new rule to enforce presence of uniqueness test. (#90)
 - Add new rule to enforce single-column PK to be defined at column level. (#90)
-- Add new rule to enforce 1 column uniqueness test to be defined at column level. (90)
+- Add new rule to enforce 1 column uniqueness test to be defined at column
+  level. (90)
 - Add `constraints` to the model schema. (#90)
 
 ## [0.9.0] - 2024-12-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 - Add debug mode to help writing new rules. (#91)
 - Fix tests without metadata. (#88)
 - Add new rule to enforce presence of uniqueness test. (#90)
+- Add new rule to enforce single-column PK to be defined at column level. (#90)
+- Add new rule to enforce 1 column uniqueness test to be defined at column level. (90)
 - Add `constraints` to the model schema. (#90)
 
 ## [0.9.0] - 2024-12-19

--- a/docs/rules/filters.md
+++ b/docs/rules/filters.md
@@ -1,0 +1,3 @@
+# Rule filters
+
+::: dbt_score.rules.filters

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Programmatic invocations: programmatic_invocations.md
   - Rules:
       - rules/generic.md
+      - rules/filters.md
   - Reference:
       - reference/cli.md
       - reference/config.md

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator, cast
 # Conditionally import dbt objects.
 try:
     DBT_INSTALLED = True
-    from dbt.cli.main import dbtRunner, dbtRunnerResult
+    from dbt.cli.main import dbtRunner, dbtRunnerResult  # type: ignore
 except ImportError:
     DBT_INSTALLED = False
 

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator, cast
 # Conditionally import dbt objects.
 try:
     DBT_INSTALLED = True
-    from dbt.cli.main import dbtRunner, dbtRunnerResult  # type: ignore
+    from dbt.cli.main import dbtRunner, dbtRunnerResult
 except ImportError:
     DBT_INSTALLED = False
 

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -187,6 +187,7 @@ class Model(HasColumnsMixin):
     config: dict[str, Any]
     meta: dict[str, Any]
     columns: list[Column]
+    constraints: list[dict[str, Any]]
     package_name: str
     database: str
     schema: str
@@ -215,6 +216,7 @@ class Model(HasColumnsMixin):
             config=node_values["config"],
             meta=node_values["meta"],
             columns=cls._get_columns(node_values, test_values),
+            constraints=node_values["constraints"],
             package_name=node_values["package_name"],
             database=node_values["database"],
             schema=node_values["schema"],

--- a/src/dbt_score/rules/filters.py
+++ b/src/dbt_score/rules/filters.py
@@ -1,0 +1,10 @@
+"""Rule filters."""
+
+from dbt_score import rule_filter
+from dbt_score.models import Model
+
+
+@rule_filter
+def is_table(model: Model) -> bool:
+    """Models that are tables."""
+    return model.config.get("materialized") in {"table", "incremental"}

--- a/src/dbt_score/rules/generic.py
+++ b/src/dbt_score/rules/generic.py
@@ -63,8 +63,8 @@ def has_uniqueness_test(model: Model) -> RuleViolation | None:
     pk_columns = None
     # At column level?
     for column in model.columns:
-        for constraint in column.constraints:
-            if constraint.type == "primary_key":
+        for column_constraint in column.constraints:
+            if column_constraint.type == "primary_key":
                 pk_columns = [column.name]
                 break
         else:
@@ -72,9 +72,9 @@ def has_uniqueness_test(model: Model) -> RuleViolation | None:
         break
     # Or at table level?
     if pk_columns is None:
-        for constraint in model.constraints:
-            if constraint["type"] == "primary_key":
-                pk_columns = constraint["columns"]
+        for model_constraint in model.constraints:
+            if model_constraint["type"] == "primary_key":
+                pk_columns = model_constraint["columns"]
                 break
 
     if pk_columns is None: # No PK, no need for uniqueness test
@@ -90,7 +90,7 @@ def has_uniqueness_test(model: Model) -> RuleViolation | None:
 
     for data_test in model.tests:
         if data_test.type == "unique_combination_of_columns":
-            if set(data_test.kwargs.get("combination_of_columns")) == set(pk_columns):
+            if set(data_test.kwargs.get("combination_of_columns")) == set(pk_columns): # type: ignore
                 return None
 
     return RuleViolation("There is no uniqueness test defined and matching the PK.")

--- a/src/dbt_score/rules/generic.py
+++ b/src/dbt_score/rules/generic.py
@@ -73,7 +73,7 @@ def single_column_uniqueness_at_column_level(model: Model) -> RuleViolation | No
         if data_test.type == "unique_combination_of_columns":
             if len(data_test.kwargs.get("combination_of_columns")) == 1:
                 return RuleViolation(
-                    f"Single-column uniqueness test must be defined as a column test."
+                    "Single-column uniqueness test must be defined as a column test."
                 )
 
 

--- a/src/dbt_score/rules/generic.py
+++ b/src/dbt_score/rules/generic.py
@@ -1,6 +1,7 @@
 """All generic rules."""
 
 from dbt_score import Model, RuleViolation, Severity, rule
+from dbt_score.rules.filters import is_table
 
 
 @rule
@@ -52,11 +53,11 @@ def has_example_sql(model: Model) -> RuleViolation | None:
                 "The model description does not include an example SQL query."
             )
 
-@rule
+@rule(rule_filters={is_table()})
 def has_uniqueness_test(model: Model) -> RuleViolation | None:
     """Model has uniqueness test for primary key."""
-    if model.config.get("materialized") not in {"table", "incremental"}:
-        return None
+    # ruff: noqa: C901 [too-complex]
+    # ruff: noqa: PLR0912 [too-many-branches]
 
     # Extract PK
     pk_columns = None

--- a/src/dbt_score/rules/generic.py
+++ b/src/dbt_score/rules/generic.py
@@ -73,8 +73,8 @@ def has_uniqueness_test(model: Model) -> RuleViolation | None:
     # Or at table level?
     if pk_columns is None:
         for model_constraint in model.constraints:
-            if model_constraint["type"] == "primary_key":
-                pk_columns = model_constraint["columns"]
+            if model_constraint.type == "primary_key":
+                pk_columns = model_constraint.columns
                 break
 
     if pk_columns is None: # No PK, no need for uniqueness test

--- a/src/dbt_score/rules/generic.py
+++ b/src/dbt_score/rules/generic.py
@@ -59,7 +59,7 @@ def single_pk_defined_at_column_level(model: Model) -> RuleViolation | None:
     """Single-column PK must be defined as a column constraint."""
     for constraint in model.constraints:
         if constraint.type == "primary_key":
-            if len(constraint.columns) == 1:
+            if constraint.columns is not None and len(constraint.columns) == 1:
                 return RuleViolation(
                     f"Single-column PK {constraint.columns[0]} must be defined as a "
                     f"column constraint."
@@ -71,7 +71,7 @@ def single_column_uniqueness_at_column_level(model: Model) -> RuleViolation | No
     """Single-column uniqueness test must be defined as a column test."""
     for data_test in model.tests:
         if data_test.type == "unique_combination_of_columns":
-            if len(data_test.kwargs.get("combination_of_columns")) == 1:
+            if len(data_test.kwargs.get("combination_of_columns", [])) == 1:
                 return RuleViolation(
                     "Single-column uniqueness test must be defined as a column test."
                 )
@@ -94,10 +94,10 @@ def has_uniqueness_test(model: Model) -> RuleViolation | None:
                 )
 
     # Composite PK
-    pk_columns = []
+    pk_columns: list[str] = []
     for model_constraint in model.constraints:
         if model_constraint.type == "primary_key":
-            pk_columns = model_constraint.columns
+            pk_columns = model_constraint.columns or []
             break
 
     if not pk_columns: # No PK, no need for uniqueness test

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -26,6 +26,7 @@
           "tags": []
         }
       },
+      "constraints": [],
       "package_name": "package",
       "database": "db",
       "schema": "schema",
@@ -56,6 +57,7 @@
           "tags": []
         }
       },
+      "constraints": [],
       "package_name": "package",
       "database": "db",
       "schema": "schema",
@@ -86,6 +88,7 @@
           "tags": []
         }
       },
+      "constraints": [],
       "package_name": "package2",
       "database": "db",
       "schema": "schema",


### PR DESCRIPTION
For models materialized as `table` or `incremental`:
- Loop over their columns to extract PK
- Loop over their tests to find a uniqueness test matching the PK columns

Consider both table- and column-level constraints and tests.