### PR TITLE
Adding `group` to model definition

### DIFF
--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -173,6 +173,7 @@ class Model(HasColumnsMixin):
         raw_code: The raw code of the model.
         language: The language of the model, e.g. sql.
         access: The access level of the model, e.g. public.
+        group: The group the model is in.
         alias: The alias of the model.
         patch_path: The yml path of the model, e.g. `package://model_dir/dir/file.yml`.
         tags: The list of tags attached to the model.
@@ -196,6 +197,7 @@ class Model(HasColumnsMixin):
     raw_code: str
     language: str
     access: str
+    group: str
     alias: str | None = None
     patch_path: str | None = None
     tags: list[str] = field(default_factory=list)
@@ -225,6 +227,7 @@ class Model(HasColumnsMixin):
             raw_code=node_values["raw_code"],
             language=node_values["language"],
             access=node_values["access"],
+            group=node_values["group"],
             alias=node_values["alias"],
             patch_path=node_values["patch_path"],
             tags=node_values["tags"],

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -36,7 +36,8 @@
       "tags": [],
       "depends_on": {},
       "language": "sql",
-      "access": "protected"
+      "access": "protected",
+      "group": null
     },
     "model.package.model2": {
       "resource_type": "model",
@@ -67,7 +68,8 @@
       "tags": [],
       "depends_on": {},
       "language": "sql",
-      "access": "public"
+      "access": "public",
+      "group": "them_over_there"
     },
     "model.package2.model1": {
       "resource_type": "model",
@@ -98,7 +100,8 @@
       "tags": [],
       "depends_on": {},
       "language": "sql",
-      "access": "public"
+      "access": "public",
+      "group": "them_over_there"
     },
     "test.package.test1": {
       "resource_type": "test",


### PR DESCRIPTION
We have several use cases where we want to make assertions about a model's [`group`](https://docs.getdbt.com/docs/collaborate/govern/model-access#groups); adding that to the model so it is accessible for rules.