### PR TITLE
Do not ignore docs/ changes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,10 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - "docs/**"
 
   push:
     branches:
       - master
-    paths-ignore:
-      - "docs/**"
 
 jobs:
   build:


### PR DESCRIPTION
To optimize builds, changes affecting only the `docs/` folder were ignored in CI.
However, `prettier` has been added in the meantime to lint/format markdown files, which can lead to unformatted files making their way to the main branch.