### PR TITLE
Alternate approach to providing access to parents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+install:
+	pre-commit install
+	pdm install --group :all
+
+lint:
+	pdm run ruff check .
+	pdm run ruff check --fix
+	pdm run mypy .
+	pdm run tox -e lint
+
+format:
+	pdm run ruff format .
+
+test:
+	pdm run tox -e py
+	pdm run pytest
+	pdm run coverage run -m pytest
+
+docs:
+	pdm run mkdocs build
+	pdm run mkdocs serve
+
+pre-commit:
+	pre-commit run --all-files

--- a/src/dbt_score/__init__.py
+++ b/src/dbt_score/__init__.py
@@ -1,6 +1,6 @@
 """Init dbt_score package."""
 
-from dbt_score.models import Model, Source
+from dbt_score.models import Model, Parents, Source
 from dbt_score.rule import Rule, RuleViolation, Severity, rule
 from dbt_score.rule_filter import RuleFilter, rule_filter
 
@@ -13,4 +13,5 @@ __all__ = [
     "Severity",
     "rule_filter",
     "rule",
+    "Parents",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Type
 
-from dbt_score import Model, Rule, RuleViolation, Severity, Source, rule
+from dbt_score import Model, Parents, Rule, RuleViolation, Severity, Source, rule
 from dbt_score.config import Config
 from dbt_score.models import ManifestLoader
 from dbt_score.rule_filter import RuleFilter, rule_filter
@@ -106,6 +106,40 @@ def decorator_rule() -> Type[Rule]:
             return RuleViolation(message="Model1 is a violation.")
 
     return example_rule
+
+
+@fixture
+def decorator_rule_model_requesting_parents() -> Type[Rule]:
+    """An example rule that requests parents for a model."""
+
+    @rule
+    def rule_model_requesting_parents(
+        model: Model, parents: Parents
+    ) -> RuleViolation | None:
+        """Evaluate model."""
+        if len(parents.models) == 0:
+            return RuleViolation(message="Parents were not provided.")
+        else:
+            return None
+
+    return rule_model_requesting_parents
+
+
+@fixture
+def decorator_rule_source_requesting_parents() -> Type[Rule]:
+    """An example rule that requests parents for a source."""
+
+    @rule
+    def rule_source_requesting_parents(
+        source: Source, parents: Parents
+    ) -> RuleViolation | None:
+        """Evaluate model."""
+        if parents != Parents():
+            return RuleViolation(message="Source doesn't have parents")
+        else:
+            return None
+
+    return rule_source_requesting_parents
 
 
 @fixture

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -33,7 +33,7 @@
       "raw_code": "SELECT x FROM {{ ref('model2') }} union all SELECT x from {{ source('table1') }}",
       "alias": "model1_alias",
       "patch_path": "/path/to/model1.yml",
-      "tags": [],
+      "tags": ["special"],
       "depends_on": {
         "nodes": ["model.package.model2", "source.package.my_source.table1"]
       },

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -30,11 +30,13 @@
       "package_name": "package",
       "database": "db",
       "schema": "schema",
-      "raw_code": "SELECT x FROM y",
+      "raw_code": "SELECT x FROM {{ ref('model2') }} union all SELECT x from {{ source('table1') }}",
       "alias": "model1_alias",
       "patch_path": "/path/to/model1.yml",
       "tags": [],
-      "depends_on": {},
+      "depends_on": {
+        "nodes": ["model.package.model2", "source.package.my_source.table1"]
+      },
       "language": "sql",
       "access": "protected",
       "group": null
@@ -62,9 +64,41 @@
       "package_name": "package",
       "database": "db",
       "schema": "schema",
-      "raw_code": "SELECT x FROM y",
+      "raw_code": "SELECT x FROM {{ source('table1') }}",
       "alias": "model2_alias",
       "patch_path": "/path/to/model2.yml",
+      "tags": [],
+      "depends_on": { "nodes": ["source.package.my_source.table1"] },
+      "language": "sql",
+      "access": "public",
+      "group": "them_over_there"
+    },
+    "model.package.model3": {
+      "resource_type": "model",
+      "unique_id": "model.package.model3",
+      "name": "model3",
+      "relation_name": "database.schema.model3",
+      "description": "A great model.\nExample use:\n```sql\nselect 1;\n```",
+      "original_file_path": "/path/to/model3.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "constraints": [],
+      "package_name": "package",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT x FROM y",
+      "alias": "model2_alias",
+      "patch_path": "/path/to/model3.yml",
       "tags": [],
       "depends_on": {},
       "language": "sql",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -41,8 +41,8 @@ def test_evaluation_low_medium_high(
     )
     evaluation.evaluate()
 
-    model1 = manifest_loader.models[0]
-    model2 = manifest_loader.models[1]
+    model1 = manifest_loader.models["model.package.model1"]
+    model2 = manifest_loader.models["model.package.model2"]
 
     assert evaluation.results[model1][rule_severity_low] is None
     assert evaluation.results[model1][rule_severity_medium] is None
@@ -54,10 +54,10 @@ def test_evaluation_low_medium_high(
     assert isinstance(evaluation.results[model2][rule_severity_high], RuleViolation)
     assert isinstance(evaluation.results[model2][rule_error], Exception)
 
-    assert mock_formatter.evaluable_evaluated.call_count == 5
+    assert mock_formatter.evaluable_evaluated.call_count == 6
     assert mock_formatter.project_evaluated.call_count == 1
 
-    assert mock_scorer.score_evaluable.call_count == 5
+    assert mock_scorer.score_evaluable.call_count == 6
     assert mock_scorer.score_aggregate_evaluables.call_count == 1
 
 
@@ -85,7 +85,7 @@ def test_evaluation_critical(
 
     evaluation.evaluate()
 
-    model2 = manifest_loader.models[1]
+    model2 = manifest_loader.models["model.package.model2"]
 
     assert isinstance(evaluation.results[model2][rule_severity_critical], RuleViolation)
 
@@ -157,8 +157,8 @@ def test_evaluation_rule_with_config(
 ):
     """Test rule evaluation with parameters."""
     manifest_loader = ManifestLoader(manifest_path)
-    model1 = manifest_loader.models[0]
-    model2 = manifest_loader.models[1]
+    model1 = manifest_loader.models["model.package.model1"]
+    model2 = manifest_loader.models["model.package.model2"]
 
     config = Config()
     config._load_toml_file(str(valid_config_path))
@@ -211,10 +211,10 @@ def test_evaluation_with_filter(
     )
     evaluation.evaluate()
 
-    model1 = manifest_loader.models[0]
-    model2 = manifest_loader.models[1]
-    source1 = manifest_loader.sources[0]
-    source2 = manifest_loader.sources[1]
+    model1 = manifest_loader.models["model.package.model1"]
+    model2 = manifest_loader.models["model.package.model2"]
+    source1 = manifest_loader.sources["source.package.my_source.table1"]
+    source2 = manifest_loader.sources["source.package.my_source.table2"]
 
     assert model_rule_with_filter not in evaluation.results[model1]
     assert isinstance(evaluation.results[model2][model_rule_with_filter], RuleViolation)
@@ -252,10 +252,10 @@ def test_evaluation_with_class_filter(
     )
     evaluation.evaluate()
 
-    model1 = manifest_loader.models[0]
-    model2 = manifest_loader.models[1]
-    source1 = manifest_loader.sources[0]
-    source2 = manifest_loader.sources[1]
+    model1 = manifest_loader.models["model.package.model1"]
+    model2 = manifest_loader.models["model.package.model2"]
+    source1 = manifest_loader.sources["source.package.my_source.table1"]
+    source2 = manifest_loader.sources["source.package.my_source.table2"]
 
     assert model_class_rule_with_filter not in evaluation.results[model1]
     assert isinstance(
@@ -292,11 +292,51 @@ def test_evaluation_with_models_and_sources(
     )
     evaluation.evaluate()
 
-    model1 = manifest_loader.models[0]
-    source1 = manifest_loader.sources[0]
+    model1 = manifest_loader.models["model.package.model1"]
+    source1 = manifest_loader.sources["source.package.my_source.table1"]
 
     assert decorator_rule in evaluation.results[model1]
     assert decorator_rule_source not in evaluation.results[model1]
 
     assert decorator_rule_source in evaluation.results[source1]
     assert decorator_rule not in evaluation.results[source1]
+
+
+def test_evaluation_with_requested_relatives(
+    manifest_path,
+    default_config,
+    decorator_rule,
+    decorator_rule_model_requesting_parents,
+    decorator_rule_source_requesting_parents,
+):
+    """Test that rules requesting relatives are provided with them."""
+    manifest_loader = ManifestLoader(manifest_path)
+    mock_formatter = Mock()
+    mock_scorer = Mock()
+
+    rule_registry = RuleRegistry(default_config)
+    rule_registry._add_rule(decorator_rule)
+    rule_registry._add_rule(decorator_rule_model_requesting_parents)
+    rule_registry._add_rule(decorator_rule_source_requesting_parents)
+
+    # Ensure we get a valid Score object from the Mock
+    mock_scorer.score_model.return_value = Score(10, "🥇")
+
+    evaluation = Evaluation(
+        rule_registry=rule_registry,
+        manifest_loader=manifest_loader,
+        formatter=mock_formatter,
+        scorer=mock_scorer,
+        config=default_config,
+    )
+    evaluation.evaluate()
+
+    model1 = manifest_loader.models["model.package.model1"]
+    source1 = manifest_loader.sources["source.package.my_source.table1"]
+
+    assert decorator_rule in evaluation.results[model1]
+    assert decorator_rule_model_requesting_parents in evaluation.results[model1]
+    assert decorator_rule_source_requesting_parents in evaluation.results[source1]
+    assert isinstance(evaluation.results[model1][decorator_rule], RuleViolation)
+    assert evaluation.results[model1][decorator_rule_model_requesting_parents] is None
+    assert evaluation.results[source1][decorator_rule_source_requesting_parents] is None

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,7 +1,8 @@
 """Test rule."""
 
+
 import pytest
-from dbt_score import Model, Rule, RuleViolation, Severity, Source, rule
+from dbt_score import Model, Parents, Rule, RuleViolation, Severity, Source, rule
 from dbt_score.rule_filter import RuleFilter, rule_filter
 
 
@@ -63,6 +64,27 @@ def test_missing_evaluate_rule_class(model1):
             """Bad example rule."""
 
             description = "Description of the rule."
+
+
+def test_get_requested_relatives(
+    decorator_rule,
+    decorator_rule_model_requesting_parents,
+    decorator_rule_source_requesting_parents,
+    model1,
+    source1,
+    manifest_loader,
+):
+    """Test that rules requesting relatives are provided with them."""
+    assert decorator_rule.get_requested_relatives(model1, manifest_loader) == {}
+
+    model2 = manifest_loader.models["model.package.model2"]
+    source1 = manifest_loader.sources["source.package.my_source.table1"]
+    assert decorator_rule_model_requesting_parents.get_requested_relatives(
+        model1, manifest_loader
+    ) == {"parents": Parents(models={model2}, sources={source1})}
+    assert decorator_rule_source_requesting_parents.get_requested_relatives(
+        source1, manifest_loader
+    ) == {"parents": Parents()}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As an alternative to my [other PR](https://github.com/PicnicSupermarket/dbt-score/pull/106), this approach feels a bit more ergonomic from an end user perspective; you can define a rule like:
```
@rule
def rule_with_parents(model: Model, parents: Parents) -> RuleViolation | None:
    if 'special' in model.tags and not all(['special' in parent.tags for parent in parents.models]):
        return RuleViolation(message="Special model depends on non-special models")
    return None
```
If the signature includes `parents: Parents`, you will receive a `Parents` object (alias for `Relatives`, which is a dataclass containing `models: set[Model]` and `sources: set[Source]`), so you can write tests about a model in the context of its parents.

This should be easily extensible to other kinds of relatives (`Children`, or with some additional thought about how to represent distance, `Ancestors` or `Descendants`).

Some things I'm not wildly confident around:
* Right now, this calculates the parents only when they're requested (via `get_parents()`); this might not be the best way to do this. My hope is that it'd be easy enough to shift it to being pre-calculated (on creation of the `ManifestLoader`), or to actually build a graph with networkx or something like that that might be more performant; less focused at the moment on the mechanics of calculating the parents than having that get done in the right place.
* The type aliasing around `ModelRuleEvaluationType` and `SourceRuleEvaluationType` feels not quite right; it works, but feels like there's likely a better way to be able to articulate "you might include `parents` (or `children`...)"
* Rather than having `Relatives` as a wrapper around lists of models / sources, could instead just do like `parents: list[Model | Source]`; that does, though, require the rule to figure out what type of parent it's dealing with.