### PR TITLE
Embedding parents and children into models, sources, and snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+install:
+	pre-commit install
+	pdm install --group :all
+
+lint:
+	pdm run ruff check .
+	pdm run ruff check --fix
+	pdm run mypy .
+	pdm run tox -e lint
+
+format:
+	pdm run ruff format .
+
+test:
+	pdm run tox -e py
+	pdm run pytest
+	pdm run coverage run -m pytest
+
+docs:
+	pdm run mkdocs build
+	pdm run mkdocs serve
+
+pre-commit:
+	pre-commit run --all-files

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -30,7 +30,7 @@
       "alias": "snapshot1_alias",
       "patch_path": "/path/to/snapshot1.yml",
       "tags": [],
-      "depends_on": {},
+      "depends_on": { "nodes": ["model.package.model1"] },
       "language": "sql",
       "access": "protected"
     },
@@ -61,7 +61,7 @@
       "alias": "snapshot2_alias",
       "patch_path": "/path/to/snapshot2.yml",
       "tags": [],
-      "depends_on": {},
+      "depends_on": { "nodes": ["source.package.my_source.table1"] },
       "language": "sql",
       "access": "protected"
     },
@@ -96,7 +96,9 @@
       "alias": "model1_alias",
       "patch_path": "/path/to/model1.yml",
       "tags": [],
-      "depends_on": {},
+      "depends_on": {
+        "nodes": ["model.package.model2", "source.package.my_source.table1"]
+      },
       "language": "sql",
       "access": "protected",
       "group": null
@@ -128,7 +130,7 @@
       "alias": "model2_alias",
       "patch_path": "/path/to/model2.yml",
       "tags": [],
-      "depends_on": {},
+      "depends_on": { "nodes": ["snapshot.package.snapshot2"] },
       "language": "sql",
       "access": "public",
       "group": "them_over_there"


### PR DESCRIPTION
Following discussion in [this issue](https://github.com/PicnicSupermarket/dbt-score/issues/98) and related draft PRs, taking a simpler approach to providing access to neighbor graph nodes:
* adding `parents: list[Model | Source | Snapshot]` to `Model` and `Snapshot` models
* adding `children: list[Model | Snapshot]` to `Source`, `Model`, and `Snapshot` models

This should allow writing rules that compare a node to its parents ("any model with tag `tier_1` may only have parents that also have tag `tier_1`") or children ("any source with tag `beta` may not have any children that do not also have tag `beta`"), to be able to make assertions about model lineage expectation. 