### PR TITLE
Adding support for exposures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-- Support linting of exposures
+- Support linting of exposures (#112)
 - Add `parents` to models and snapshots, allowing access to parent nodes. (#109)
 
 ## [0.11.0] - 2025-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Support linting of exposures
 - Add `parents` to models and snapshots, allowing access to parent nodes. (#109)
 
 ## [0.11.0] - 2025-04-04

--- a/docs/create_rules.md
+++ b/docs/create_rules.md
@@ -32,7 +32,7 @@ function is its description. Therefore, it is important to use a
 self-explanatory name for the function and document it well.
 
 The type annotation for the rule's argument dictates whether the rule should be
-applied to dbt models, sources or snapshots.
+applied to dbt models, sources, snapshots, or exposures.
 
 Here is the same example rule, applied to sources:
 
@@ -139,8 +139,8 @@ class SkipSchemaY(RuleFilter):
       return model.schema.lower() != 'y'
 ```
 
-Filters also rely on type-annotations to dictate whether they apply to models
-sources or snapshots:
+Filters also rely on type-annotations to dictate whether they apply to models,
+sources, snapshots, or exposures:
 
 ```python
 from dbt_score import RuleFilter, rule_filter, Source

--- a/docs/create_rules.md
+++ b/docs/create_rules.md
@@ -32,7 +32,7 @@ function is its description. Therefore, it is important to use a
 self-explanatory name for the function and document it well.
 
 The type annotation for the rule's argument dictates whether the rule should be
-applied to dbt models, sources, snapshots, or exposures.
+applied to dbt models, sources, snapshots, seeds, or exposures.
 
 Here is the same example rule, applied to sources:
 
@@ -140,7 +140,7 @@ class SkipSchemaY(RuleFilter):
 ```
 
 Filters also rely on type-annotations to dictate whether they apply to models,
-sources, snapshots, or exposures:
+sources, snapshots, seeds, or exposures:
 
 ```python
 from dbt_score import RuleFilter, rule_filter, Source

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ encourage) good practices. The dbt entities that `dbt-score` is able to lint
 - Models
 - Sources
 - Snapshots
+- Exposures
 
 ## Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ encourage) good practices. The dbt entities that `dbt-score` is able to lint
 - Sources
 - Snapshots
 - Exposures
+- Seeds
 
 ## Example
 

--- a/src/dbt_score/__init__.py
+++ b/src/dbt_score/__init__.py
@@ -1,17 +1,18 @@
 """Init dbt_score package."""
 
-from dbt_score.models import Model, Snapshot, Source
+from dbt_score.models import Exposure, Model, Snapshot, Source
 from dbt_score.rule import Rule, RuleViolation, Severity, rule
 from dbt_score.rule_filter import RuleFilter, rule_filter
 
 __all__ = [
+    "Exposure",
     "Model",
-    "Source",
-    "Snapshot",
-    "RuleFilter",
     "Rule",
+    "RuleFilter",
     "RuleViolation",
     "Severity",
-    "rule_filter",
+    "Snapshot",
+    "Source",
     "rule",
+    "rule_filter",
 ]

--- a/src/dbt_score/__init__.py
+++ b/src/dbt_score/__init__.py
@@ -12,11 +12,8 @@ __all__ = [
     "Seed",
     "RuleFilter",
     "Rule",
-    "RuleFilter",
     "RuleViolation",
     "Severity",
-    "Snapshot",
-    "Source",
     "rule",
     "rule_filter",
 ]

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -74,6 +74,7 @@ def dbt_ls(select: Iterable[str] | None) -> Iterable[str]:
         "--resource-types",
         "model",
         "source",
+        "snapshot",
         "exposure",
         "--output",
         "name",

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -69,7 +69,15 @@ def dbt_parse() -> "dbtRunnerResult":
 @dbt_required
 def dbt_ls(select: Iterable[str] | None) -> Iterable[str]:
     """Run dbt ls."""
-    cmd = ["ls", "--resource-types", "model", "source", "snapshot", "--output", "name"]
+    cmd = [
+        "ls",
+        "--resource-types",
+        "model",
+        "source",
+        "exposure",
+        "--output",
+        "name",
+    ]
     if select:
         cmd += ["--select", *select]
 

--- a/src/dbt_score/evaluation.py
+++ b/src/dbt_score/evaluation.py
@@ -64,6 +64,7 @@ class Evaluation:
             self._manifest_loader.models.values(),
             self._manifest_loader.sources.values(),
             self._manifest_loader.snapshots.values(),
+            self._manifest_loader.exposures.values(),
         ):
             # type inference on elements from `chain` is wonky
             # and resolves to superclass HasColumnsMixin
@@ -97,5 +98,6 @@ class Evaluation:
             self._manifest_loader.models
             or self._manifest_loader.sources
             or self._manifest_loader.snapshots
+            or self._manifest_loader.exposures
         ):
             self._formatter.project_evaluated(self.project_score)

--- a/src/dbt_score/formatters/human_readable_formatter.py
+++ b/src/dbt_score/formatters/human_readable_formatter.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from dbt_score.evaluation import EvaluableResultsType
 from dbt_score.formatters import Formatter
-from dbt_score.models import Evaluable, Model, Snapshot, Source
+from dbt_score.models import Evaluable, Exposure, Model, Snapshot, Source
 from dbt_score.rule import RuleViolation
 from dbt_score.scoring import Score
 
@@ -36,6 +36,8 @@ class HumanReadableFormatter(Formatter):
             case Source():
                 return evaluable.selector_name
             case Snapshot():
+                return evaluable.name
+            case Exposure():
                 return evaluable.name
             case _:
                 raise NotImplementedError

--- a/src/dbt_score/formatters/manifest_formatter.py
+++ b/src/dbt_score/formatters/manifest_formatter.py
@@ -36,4 +36,8 @@ class ManifestFormatter(Formatter):
                 source_manifest = manifest["sources"][evaluable_id]
                 source_manifest["meta"]["score"] = evaluable_score.value
                 source_manifest["meta"]["badge"] = evaluable_score.badge
+            if evaluable_id.startswith("exposure"):
+                exposure_manifest = manifest["exposures"][evaluable_id]
+                exposure_manifest["meta"]["score"] = evaluable_score.value
+                exposure_manifest["meta"]["badge"] = evaluable_score.badge
         print(json.dumps(manifest, indent=2))

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -500,9 +500,11 @@ class Exposure:
         original_file_path: The path to the exposure file
             (e.g. `models/exposures/exposures.yml`).
         type: The type of the exposure, e.g. `application`.
-        owner: The owner of the exposure.
+        owner: The owner of the exposure,
+            e.g. `{"name": "owner", "email": "owner@email.com"}`.
         config: The config of the exposure.
         meta: The meta of the exposure.
+        tags: The list of tags attached to the exposure.
         depends_on: The depends_on of the exposure.
         parents: The list of models, sources, and snapshot this exposure depends on.
         _raw_values: The raw values of the exposure in the manifest.
@@ -516,9 +518,10 @@ class Exposure:
     maturity: str
     original_file_path: str
     type: str
-    owner: str
+    owner: dict[str, Any]
     config: dict[str, Any]
     meta: dict[str, Any]
+    tags: list[str]
     depends_on: dict[str, list[str]] = field(default_factory=dict)
     parents: list[Union["Model", "Source", "Snapshot"]] = field(default_factory=list)
     _raw_values: dict[str, Any] = field(default_factory=dict)
@@ -538,6 +541,7 @@ class Exposure:
             owner=node_values["owner"],
             config=node_values["config"],
             meta=node_values["meta"],
+            tags=node_values["tags"],
             depends_on=node_values["depends_on"],
             _raw_values=node_values,
         )

--- a/src/dbt_score/rule.py
+++ b/src/dbt_score/rule.py
@@ -14,7 +14,7 @@ from typing import (
     overload,
 )
 
-from dbt_score.models import Evaluable, Model, Snapshot, Source
+from dbt_score.models import Evaluable, Exposure, Model, Snapshot, Source
 from dbt_score.more_itertools import first_true
 from dbt_score.rule_filter import RuleFilter
 
@@ -66,8 +66,12 @@ class RuleViolation:
 ModelRuleEvaluationType: TypeAlias = Callable[[Model], RuleViolation | None]
 SourceRuleEvaluationType: TypeAlias = Callable[[Source], RuleViolation | None]
 SnapshotRuleEvaluationType: TypeAlias = Callable[[Snapshot], RuleViolation | None]
+ExposureRuleEvaluationType: TypeAlias = Callable[[Exposure], RuleViolation | None]
 RuleEvaluationType: TypeAlias = (
-    ModelRuleEvaluationType | SourceRuleEvaluationType | SnapshotRuleEvaluationType
+    ModelRuleEvaluationType
+    | SourceRuleEvaluationType
+    | SnapshotRuleEvaluationType
+    | ExposureRuleEvaluationType
 )
 
 
@@ -203,6 +207,11 @@ def rule(__func: SourceRuleEvaluationType) -> Type[Rule]:
 
 @overload
 def rule(__func: SnapshotRuleEvaluationType) -> Type[Rule]:
+    ...
+
+
+@overload
+def rule(__func: ExposureRuleEvaluationType) -> Type[Rule]:
     ...
 
 

--- a/src/dbt_score/rule_filter.py
+++ b/src/dbt_score/rule_filter.py
@@ -4,16 +4,18 @@ import inspect
 import typing
 from typing import Any, Callable, Type, TypeAlias, cast, overload
 
-from dbt_score.models import Evaluable, Model, Snapshot, Source
+from dbt_score.models import Evaluable, Exposure, Model, Snapshot, Source
 from dbt_score.more_itertools import first_true
 
 ModelFilterEvaluationType: TypeAlias = Callable[[Model], bool]
 SourceFilterEvaluationType: TypeAlias = Callable[[Source], bool]
 SnapshotFilterEvaluationType: TypeAlias = Callable[[Snapshot], bool]
+ExposureFilterEvaluationType: TypeAlias = Callable[[Exposure], bool]
 FilterEvaluationType: TypeAlias = (
     ModelFilterEvaluationType
     | SourceFilterEvaluationType
     | SnapshotFilterEvaluationType
+    | ExposureFilterEvaluationType
 )
 
 
@@ -48,7 +50,7 @@ class RuleFilter:
         if not resource_type_argument:
             raise TypeError(
                 "Subclass must implement method `evaluate` with an "
-                "annotated Model, Snapshot or Source argument."
+                "annotated Model, Snapshot, Source or Exposure argument."
             )
 
         resource_type = cast(type[Evaluable], resource_type_argument.annotation)
@@ -84,6 +86,11 @@ def rule_filter(__func: SourceFilterEvaluationType) -> Type[RuleFilter]:
 
 @overload
 def rule_filter(__func: SnapshotFilterEvaluationType) -> Type[RuleFilter]:
+    ...
+
+
+@overload
+def rule_filter(__func: ExposureFilterEvaluationType) -> Type[RuleFilter]:
     ...
 
 

--- a/src/dbt_score/rule_filter.py
+++ b/src/dbt_score/rule_filter.py
@@ -52,7 +52,7 @@ class RuleFilter:
         if not resource_type_argument:
             raise TypeError(
                 "Subclass must implement method `evaluate` with an "
-                "annotated Model, Snapshot, Source or Exposure argument."
+                "annotated Model, Snapshot, Source, Seed or Exposure argument."
             )
 
         resource_type = cast(type[Evaluable], resource_type_argument.annotation)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,16 @@ import json
 from pathlib import Path
 from typing import Any, Type
 
-from dbt_score import Model, Rule, RuleViolation, Severity, Snapshot, Source, rule
+from dbt_score import (
+    Exposure,
+    Model,
+    Rule,
+    RuleViolation,
+    Severity,
+    Snapshot,
+    Source,
+    rule,
+)
 from dbt_score.config import Config
 from dbt_score.models import ManifestLoader
 from dbt_score.rule_filter import RuleFilter, rule_filter
@@ -105,6 +114,21 @@ def snapshot1(raw_manifest) -> Snapshot:
 def snapshot2(raw_manifest) -> Snapshot:
     """Snapshot 2."""
     return Snapshot.from_node(raw_manifest["nodes"]["snapshot.package.snapshot2"], [])
+
+
+# Exposures
+
+
+@fixture
+def exposure1(raw_manifest) -> Exposure:
+    """Exposure 1."""
+    return Exposure.from_node(raw_manifest["nodes"]["exposure.package.exposure1"])
+
+
+@fixture
+def exposure2(raw_manifest) -> Exposure:
+    """Exposure 2."""
+    return Exposure.from_node(raw_manifest["nodes"]["exposure.package.exposure2"])
 
 
 # Multiple ways to create rules
@@ -216,6 +240,61 @@ def class_rule_snapshot() -> Type[Rule]:
             """Evaluate snapshot."""
             if snapshot.name == "snapshot1":
                 return RuleViolation(message="Snapshot1 is a violation.")
+
+    return ExampleRule
+
+
+@fixture
+def decorator_rule_exposure() -> Type[Rule]:
+    """An example rule created with the rule decorator."""
+
+    @rule
+    def example_rule(exposure: Exposure) -> RuleViolation | None:
+        """Description of the rule."""
+        if exposure.name == "exposure1":
+            return RuleViolation(message="Exposure1 is a violation.")
+
+    return example_rule
+
+
+@fixture
+def decorator_rule_no_parens_exposure() -> Type[Rule]:
+    """An example rule created with the rule decorator without parentheses."""
+
+    @rule
+    def example_rule(exposure: Exposure) -> RuleViolation | None:
+        """Description of the rule."""
+        if exposure.name == "exposure1":
+            return RuleViolation(message="Exposure1 is a violation.")
+
+    return example_rule
+
+
+@fixture
+def decorator_rule_args_exposure() -> Type[Rule]:
+    """An example rule created with the rule decorator with arguments."""
+
+    @rule(description="Description of the rule.")
+    def example_rule(exposure: Exposure) -> RuleViolation | None:
+        if exposure.name == "exposure1":
+            return RuleViolation(message="Exposure1 is a violation.")
+
+    return example_rule
+
+
+@fixture
+def class_rule_exposure() -> Type[Rule]:
+    """An example rule created with a class."""
+
+    class ExampleRule(Rule):
+        """Example rule."""
+
+        description = "Description of the rule."
+
+        def evaluate(self, exposure: Exposure) -> RuleViolation | None:  # type: ignore[override]
+            """Evaluate exposure."""
+            if exposure.name == "exposure1":
+                return RuleViolation(message="Exposure1 is a violation.")
 
     return ExampleRule
 
@@ -469,3 +548,20 @@ def snapshot_class_rule_with_filter() -> Type[Rule]:
             return RuleViolation(message="I always fail.")
 
     return SnapshotRuleWithFilter
+
+
+@fixture
+def exposure_rule_with_filter() -> Type[Rule]:
+    """An example rule that skips through a filter."""
+
+    @rule_filter
+    def skip_exposure1(exposure: Exposure) -> bool:
+        """Skips for exposure1, passes for exposure2."""
+        return exposure.name != "exposure1"
+
+    @rule(rule_filters={skip_exposure1()})
+    def exposure_rule_with_filter(exposure: Exposure) -> RuleViolation | None:
+        """Rule that always fails when not filtered."""
+        return RuleViolation(message="I always fail.")
+
+    return exposure_rule_with_filter

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -385,5 +385,83 @@
       "relation_name": "\"package\".\"my_other_source\".\"table1\"",
       "created_at": 1728529440.4206917
     }
+  },
+  "exposures": {
+    "exposure.package.exposure1": {
+      "name": "exposure1",
+      "resource_type": "exposure",
+      "package_name": "package",
+      "path": "models/exposures/exposures.yml",
+      "original_file_path": "models/exposures/exposures.yml",
+      "unique_id": "exposure.package.exposure1",
+      "fqn": ["package", "exposures", "exposure1"],
+      "type": "application",
+      "owner": {
+        "email": null,
+        "name": "owner"
+      },
+      "description": "This is a description.",
+      "label": null,
+      "maturity": null,
+      "meta": {},
+      "tags": ["tag1", "tag2"],
+      "config": {
+        "enabled": true
+      },
+      "unrendered_config": {},
+      "url": null,
+      "depends_on": {
+        "macros": [],
+        "nodes": ["model.package.model1"]
+      },
+      "refs": [
+        {
+          "name": "model1",
+          "package": null,
+          "version": null
+        }
+      ],
+      "sources": [],
+      "metrics": [],
+      "created_at": 1744832856.199685
+    },
+    "exposure.package.exposure2": {
+      "name": "exposure2",
+      "resource_type": "exposure",
+      "package_name": "package",
+      "path": "models/exposures/exposures.yml",
+      "original_file_path": "models/exposures/exposures.yml",
+      "unique_id": "exposure.package.exposure2",
+      "fqn": ["package", "exposures", "exposure2"],
+      "type": "application",
+      "owner": {
+        "email": null,
+        "name": "owner"
+      },
+      "description": "This is a description.",
+      "label": null,
+      "maturity": null,
+      "meta": {},
+      "tags": ["tag1", "tag2"],
+      "config": {
+        "enabled": true
+      },
+      "unrendered_config": {},
+      "url": null,
+      "depends_on": {
+        "macros": [],
+        "nodes": ["model.package.model2"]
+      },
+      "refs": [
+        {
+          "name": "model2",
+          "package": null,
+          "version": null
+        }
+      ],
+      "sources": [],
+      "metrics": [],
+      "created_at": 1744832856.199685
+    }
   }
 }

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -251,6 +251,7 @@ def test_evaluation_with_class_filter(
     model_class_rule_with_filter,
     source_class_rule_with_filter,
     snapshot_class_rule_with_filter,
+    exposure_class_rule_with_filter,
 ):
     """Test rule with filters and filtered rules defined by classes."""
     manifest_loader = ManifestLoader(manifest_path)
@@ -261,7 +262,7 @@ def test_evaluation_with_class_filter(
     rule_registry._add_rule(model_class_rule_with_filter)
     rule_registry._add_rule(source_class_rule_with_filter)
     rule_registry._add_rule(snapshot_class_rule_with_filter)
-
+    rule_registry._add_rule(exposure_class_rule_with_filter)
     # Ensure we get a valid Score object from the Mock
     mock_scorer.score_model.return_value = Score(10, "🥇")
 
@@ -280,6 +281,8 @@ def test_evaluation_with_class_filter(
     source2 = manifest_loader.sources["source.package.my_source.table2"]
     snapshot1 = manifest_loader.snapshots["snapshot.package.snapshot1"]
     snapshot2 = manifest_loader.snapshots["snapshot.package.snapshot2"]
+    exposure1 = manifest_loader.exposures["exposure.package.exposure1"]
+    exposure2 = manifest_loader.exposures["exposure.package.exposure2"]
 
     assert model_class_rule_with_filter not in evaluation.results[model1]
     assert isinstance(
@@ -296,6 +299,11 @@ def test_evaluation_with_class_filter(
         evaluation.results[snapshot2][snapshot_class_rule_with_filter], RuleViolation
     )
 
+    assert exposure_class_rule_with_filter not in evaluation.results[exposure1]
+    assert isinstance(
+        evaluation.results[exposure2][exposure_class_rule_with_filter], RuleViolation
+    )
+
 
 def test_evaluation_with_models_and_sources(
     manifest_path,
@@ -303,6 +311,7 @@ def test_evaluation_with_models_and_sources(
     decorator_rule,
     decorator_rule_source,
     decorator_rule_snapshot,
+    decorator_rule_exposure,
 ):
     """Test that model rules apply to models and vice versa."""
     manifest_loader = ManifestLoader(manifest_path)
@@ -313,6 +322,7 @@ def test_evaluation_with_models_and_sources(
     rule_registry._add_rule(decorator_rule)
     rule_registry._add_rule(decorator_rule_source)
     rule_registry._add_rule(decorator_rule_snapshot)
+    rule_registry._add_rule(decorator_rule_exposure)
 
     # Ensure we get a valid Score object from the Mock
     mock_scorer.score_model.return_value = Score(10, "🥇")
@@ -329,15 +339,24 @@ def test_evaluation_with_models_and_sources(
     model1 = manifest_loader.models["model.package.model1"]
     source1 = manifest_loader.sources["source.package.my_source.table1"]
     snapshot1 = manifest_loader.snapshots["snapshot.package.snapshot1"]
+    exposure1 = manifest_loader.exposures["exposure.package.exposure1"]
 
     assert decorator_rule in evaluation.results[model1]
     assert decorator_rule_source not in evaluation.results[model1]
     assert decorator_rule_snapshot not in evaluation.results[model1]
+    assert decorator_rule_exposure not in evaluation.results[model1]
 
     assert decorator_rule_source in evaluation.results[source1]
     assert decorator_rule not in evaluation.results[source1]
     assert decorator_rule_snapshot not in evaluation.results[source1]
+    assert decorator_rule_exposure not in evaluation.results[source1]
 
     assert decorator_rule_snapshot in evaluation.results[snapshot1]
     assert decorator_rule_source not in evaluation.results[snapshot1]
     assert decorator_rule not in evaluation.results[snapshot1]
+    assert decorator_rule_exposure not in evaluation.results[snapshot1]
+
+    assert decorator_rule_exposure in evaluation.results[exposure1]
+    assert decorator_rule not in evaluation.results[exposure1]
+    assert decorator_rule_source not in evaluation.results[exposure1]
+    assert decorator_rule_snapshot not in evaluation.results[exposure1]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -54,10 +54,10 @@ def test_evaluation_low_medium_high(
     assert isinstance(evaluation.results[model2][rule_severity_high], RuleViolation)
     assert isinstance(evaluation.results[model2][rule_error], Exception)
 
-    assert mock_formatter.evaluable_evaluated.call_count == 7
+    assert mock_formatter.evaluable_evaluated.call_count == 9
     assert mock_formatter.project_evaluated.call_count == 1
 
-    assert mock_scorer.score_evaluable.call_count == 7
+    assert mock_scorer.score_evaluable.call_count == 9
     assert mock_scorer.score_aggregate_evaluables.call_count == 1
 
 
@@ -193,6 +193,7 @@ def test_evaluation_with_filter(
     model_rule_with_filter,
     source_rule_with_filter,
     snapshot_rule_with_filter,
+    exposure_rule_with_filter,
 ):
     """Test rule with filter."""
     manifest_loader = ManifestLoader(manifest_path)
@@ -203,7 +204,7 @@ def test_evaluation_with_filter(
     rule_registry._add_rule(model_rule_with_filter)
     rule_registry._add_rule(source_rule_with_filter)
     rule_registry._add_rule(snapshot_rule_with_filter)
-
+    rule_registry._add_rule(exposure_rule_with_filter)
     # Ensure we get a valid Score object from the Mock
     mock_scorer.score_model.return_value = Score(10, "🥇")
 
@@ -222,6 +223,8 @@ def test_evaluation_with_filter(
     source2 = manifest_loader.sources["source.package.my_source.table2"]
     snapshot1 = manifest_loader.snapshots["snapshot.package.snapshot1"]
     snapshot2 = manifest_loader.snapshots["snapshot.package.snapshot2"]
+    exposure1 = manifest_loader.exposures["exposure.package.exposure1"]
+    exposure2 = manifest_loader.exposures["exposure.package.exposure2"]
 
     assert model_rule_with_filter not in evaluation.results[model1]
     assert isinstance(evaluation.results[model2][model_rule_with_filter], RuleViolation)
@@ -234,6 +237,11 @@ def test_evaluation_with_filter(
     assert snapshot_rule_with_filter not in evaluation.results[snapshot1]
     assert isinstance(
         evaluation.results[snapshot2][snapshot_rule_with_filter], RuleViolation
+    )
+
+    assert exposure_rule_with_filter not in evaluation.results[exposure1]
+    assert isinstance(
+        evaluation.results[exposure2][exposure_rule_with_filter], RuleViolation
     )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -48,6 +48,10 @@ def test_manifest_load(mock_read_text, raw_manifest):
             loader.sources["source.package.my_source.table1"]
         ]
 
+        assert loader.exposures["exposure.package.exposure1"].parents == [
+            loader.models["model.package.model1"]
+        ]
+
 
 @patch("dbt_score.models.Path.read_text")
 def test_manifest_select_models_simple(mock_read_text, raw_manifest):

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,7 +1,16 @@
 """Test rule."""
 
 import pytest
-from dbt_score import Model, Rule, RuleViolation, Severity, Snapshot, Source, rule
+from dbt_score import (
+    Exposure,
+    Model,
+    Rule,
+    RuleViolation,
+    Severity,
+    Snapshot,
+    Source,
+    rule,
+)
 from dbt_score.rule_filter import RuleFilter, rule_filter
 
 
@@ -80,6 +89,10 @@ def test_missing_evaluate_rule_class(model1):
         ("decorator_rule_no_parens_snapshot", Snapshot),
         ("decorator_rule_args_snapshot", Snapshot),
         ("class_rule_snapshot", Snapshot),
+        ("decorator_rule_exposure", Exposure),
+        ("decorator_rule_no_parens_exposure", Exposure),
+        ("decorator_rule_args_exposure", Exposure),
+        ("class_rule_exposure", Exposure),
     ],
 )
 def test_rule_introspects_its_resource_type(request, rule_fixture, expected_type):


### PR DESCRIPTION
As discussed in [this issue](https://github.com/PicnicSupermarket/dbt-score/issues/111), adding exposures as a type of evaluable. I believe I've got it plugged into all the right places - tests pass, and I can run rules locally along the lines of the below made-up example:
```
@rule(severity=Severity.CRITICAL)
def exposures_must_have_owner(exposure: Exposure) -> RuleViolation | None:
    """Exposures may not be owned by Data Team"""
    if exposure.owner["name"] == "Data Team":
        return RuleViolation(
            message=f"Exposure {exposure.name} may not have an owner {exposure.owner['name']}"
        )
    return None
```

Let me know if I've missed anywhere obvious?