### PR TITLE
Adding children in addition to parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to
 ## [Unreleased]
 
 - Add support for linting and scoring dbt seeds (#110)
+- Add `children` to models, snapshots, and sources. (#113)
 - Add `parents` to models and snapshots, allowing access to parent nodes. (#109)
 
 ## [0.11.0] - 2025-04-04

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -671,7 +671,7 @@ class ManifestLoader:
                     self.tests[node_unique_id].append(node_values)
 
     def _populate_relatives(self) -> None:
-        """Populate `parents` and `children` for all evaluables"""
+        """Populate `parents` and `children` for all evaluables."""
         for node in list(self.models.values()) + list(self.snapshots.values()):
             for parent_id in node.depends_on.get("nodes", []):
                 if parent_id in self.models:

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, List, Literal, TypeAlias, Union
+from typing import Any, Iterable, Literal, TypeAlias, Union
 
 from dbt_score.dbt_utils import dbt_ls
 

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -671,7 +671,7 @@ class ManifestLoader:
                     self.tests[node_unique_id].append(node_values)
 
     def _populate_relatives(self) -> None:
-        """Populate `parents` and `children` for all models, sources and snapshots."""
+        """Populate `parents` and `children` for all evaluables"""
         for node in list(self.models.values()) + list(self.snapshots.values()):
             for parent_id in node.depends_on.get("nodes", []):
                 if parent_id in self.models:

--- a/tests/resources/manifest.json
+++ b/tests/resources/manifest.json
@@ -134,7 +134,9 @@
       "alias": "model2_alias",
       "patch_path": "/path/to/model2.yml",
       "tags": [],
-      "depends_on": {},
+      "depends_on": {
+        "nodes": ["seed.package.seed1"]
+      },
       "language": "sql",
       "access": "public",
       "group": "them_over_there"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,14 +40,24 @@ def test_manifest_load(mock_read_text, raw_manifest):
         assert loader.snapshots["snapshot.package.snapshot1"].parents == [
             loader.models["model.package.model1"]
         ]
+        assert loader.models["model.package.model1"].children == [
+            loader.snapshots["snapshot.package.snapshot1"]
+        ]
         assert loader.models["model.package.model1"].parents == [
             loader.models["model.package.model2"],
             loader.sources["source.package.my_source.table1"],
             loader.snapshots["snapshot.package.snapshot2"],
         ]
+        assert loader.models["model.package.model2"].children == [
+            loader.models["model.package.model1"]
+        ]
         assert loader.models["model.package.model2"].parents == []
         assert loader.snapshots["snapshot.package.snapshot2"].parents == [
             loader.sources["source.package.my_source.table1"]
+        ]
+        assert loader.sources["source.package.my_source.table1"].children == [
+            loader.models["model.package.model1"],
+            loader.snapshots["snapshot.package.snapshot2"],
         ]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,13 +51,18 @@ def test_manifest_load(mock_read_text, raw_manifest):
         assert loader.models["model.package.model2"].children == [
             loader.models["model.package.model1"]
         ]
-        assert loader.models["model.package.model2"].parents == []
+        assert loader.models["model.package.model2"].parents == [
+            loader.seeds["seed.package.seed1"]
+        ]
         assert loader.snapshots["snapshot.package.snapshot2"].parents == [
             loader.sources["source.package.my_source.table1"]
         ]
         assert loader.sources["source.package.my_source.table1"].children == [
             loader.models["model.package.model1"],
             loader.snapshots["snapshot.package.snapshot2"],
+        ]
+        assert loader.seeds["seed.package.seed1"].children == [
+            loader.models["model.package.model2"]
         ]
 
 


### PR DESCRIPTION
As discussed [here](https://github.com/PicnicSupermarket/dbt-score/issues/111), adding `children` to models / sources / snapshots. This is a simple addition to the logic that populates parents; basically, if `x` is one of `y`'s parents, then `y` is one of `x`'s children.

This allows writing rules like:
```
@rule(severity=Severity.CRITICAL)
def children_of_beta_models_should_be_beta_models(
    model: Model,
) -> RuleViolation | None:
    """Children of beta models should be beta models"""
    if "beta" in model.tags:
        for child in model.children:
            if "beta" not in child.tags:
                return RuleViolation(
                    message=f"Beta model {model.name} has a child that isn't a beta model {child.name}"
                )
    return None
```

This will need to be updated slightly for new evaluable types, but that should be easy.