### PR TITLE
adding `--selected-rule`

### DIFF
--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -67,6 +67,12 @@ def cli() -> None:
     multiple=True,
 )
 @click.option(
+    "--selected-rule",
+    help="Rule to select.",
+    default=None,
+    multiple=True,
+)
+@click.option(
     "--manifest",
     "-m",
     help="Manifest filepath.",
@@ -121,6 +127,7 @@ def lint(  # noqa: PLR0912, PLR0913, C901
     select: tuple[str],
     namespace: list[str],
     disabled_rule: list[str],
+    selected_rule: list[str],
     manifest: Path,
     run_dbt_parse: bool,
     fail_project_under: float,
@@ -136,12 +143,19 @@ def lint(  # noqa: PLR0912, PLR0913, C901
     if manifest_provided and run_dbt_parse:
         raise click.UsageError("--run-dbt-parse cannot be used with --manifest.")
 
+    if len(selected_rule) > 0 and len(disabled_rule) > 0:
+        raise click.UsageError(
+            "--disabled-rule and --selected-rule cannot be used together."
+        )
+
     config = Config()
     config.load()
     if namespace:
         config.overload({"rule_namespaces": namespace})
     if disabled_rule:
         config.overload({"disabled_rules": disabled_rule})
+    if selected_rule:
+        config.overload({"selected_rules": selected_rule})
     if fail_project_under:
         config.overload({"fail_project_under": fail_project_under})
     if fail_any_item_under:
@@ -195,6 +209,12 @@ def lint(  # noqa: PLR0912, PLR0913, C901
     multiple=True,
 )
 @click.option(
+    "--selected-rule",
+    help="Rule to select.",
+    default=None,
+    multiple=True,
+)
+@click.option(
     "--title",
     help="Page title (Markdown only).",
     default=None,
@@ -207,14 +227,25 @@ def lint(  # noqa: PLR0912, PLR0913, C901
     default="terminal",
 )
 def list_command(
-    namespace: list[str], disabled_rule: list[str], title: str, format: str
+    namespace: list[str],
+    disabled_rule: list[str],
+    selected_rule: list[str],
+    title: str,
+    format: str,
 ) -> None:
     """Display rules list."""
+    if len(selected_rule) > 0 and len(disabled_rule) > 0:
+        raise click.UsageError(
+            "--disabled-rule and --selected-rule cannot be used together."
+        )
+
     config = Config()
     config.load()
     if namespace:
         config.overload({"rule_namespaces": namespace})
     if disabled_rule:
         config.overload({"disabled_rules": disabled_rule})
+    if selected_rule:
+        config.overload({"selected_rules": selected_rule})
 
     display_catalog(config, title, format)

--- a/src/dbt_score/config.py
+++ b/src/dbt_score/config.py
@@ -54,6 +54,7 @@ class Config:
     _options: Final[list[str]] = [
         "rule_namespaces",
         "disabled_rules",
+        "selected_rules",
         "inject_cwd_in_python_path",
         "fail_project_under",
         "fail_any_item_under",
@@ -67,6 +68,7 @@ class Config:
         """Initialize the Config object."""
         self.rule_namespaces: list[str] = ["dbt_score.rules", "dbt_score_rules"]
         self.disabled_rules: list[str] = []
+        self.selected_rules: list[str] = []
         self.inject_cwd_in_python_path = True
         self.rules_config: dict[str, RuleConfig] = {}
         self.config_file: Path | None = None

--- a/src/dbt_score/rule_registry.py
+++ b/src/dbt_score/rule_registry.py
@@ -79,7 +79,13 @@ class RuleRegistry:
         rule_name = rule.source()
         if rule_name in self._rules:
             raise DuplicatedRuleException(rule_name)
-        if rule_name not in self.config.disabled_rules:
+        if (
+            len(self.config.selected_rules) > 0
+            and rule_name in self.config.selected_rules
+        ) or (
+            len(self.config.selected_rules) == 0
+            and rule_name not in self.config.disabled_rules
+        ):
             rule_config = self.config.rules_config.get(rule_name, RuleConfig())
             self._rules[rule_name] = rule(rule_config=rule_config)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,24 @@ def test_invalid_options():
         assert result.exit_code == 2  # pylint: disable=PLR2004
 
 
+def test_selected_and_disabled_rule_options_mutually_exclusive():
+    """Test selected and disabled rule options are mutually exclusive."""
+    runner = CliRunner()
+    with patch("dbt_score.cli.Config._load_toml_file"):
+        result = runner.invoke(
+            lint,
+            [
+                "--manifest",
+                "fake_manifest.json",
+                "--selected-rule",
+                "foo",
+                "--disabled-rule",
+                "bar",
+            ],
+        )
+        assert result.exit_code == 2  # pylint: disable=PLR2004
+
+
 def test_lint_existing_manifest(manifest_path):
     """Test lint with an existing manifest."""
     runner = CliRunner()

--- a/tests/test_rule_registry.py
+++ b/tests/test_rule_registry.py
@@ -32,6 +32,33 @@ def test_disabled_rule_registry_discovery():
     ]
 
 
+def test_selected_rule_registry_discovery():
+    """Ensure only selected rules are discovered."""
+    config = Config()
+    config.selected_rules = ["tests.rules.nested.example.rule_test_nested_example"]
+    r = RuleRegistry(config)
+    r._load("tests.rules")
+    assert sorted(r._rules.keys()) == [
+        "tests.rules.nested.example.rule_test_nested_example"
+    ]
+
+
+def test_selected_and_disabled_rule_registry_discovery():
+    """Ensure selected rules are run even if otherwise disabled.
+
+    This is prevented by the CLI, but want to confirm selected rules
+    are run even if disabled via pyproject.toml.
+    """
+    config = Config()
+    config.selected_rules = ["tests.rules.nested.example.rule_test_nested_example"]
+    config.disabled_rules = ["tests.rules.nested.example.rule_test_nested_example"]
+    r = RuleRegistry(config)
+    r._load("tests.rules")
+    assert sorted(r._rules.keys()) == [
+        "tests.rules.nested.example.rule_test_nested_example"
+    ]
+
+
 def test_configured_rule_registry_discovery(valid_config_path):
     """Ensure rules are discovered and configured correctly."""
     config = Config()


### PR DESCRIPTION
As discussed in https://github.com/PicnicSupermarket/dbt-score/issues/118, adding a `--selected-rule` CLI flag to enable only specific rules to be run, either for testing during rules development or in specialized cases for wanting to run narrowly scoped rulesets as a part of CI.

Intended behavior:
* adding `--selected-rule` CLI flag, which is mutually exclusive with `--disabled-rule`
* If `--selected-rule` is provided, the list of selected rules will be executed, even if they are disabled by pyproject.toml

Added some tests, and manual validation confirms it appears to be working as expected.