### PR TITLE
Fix column test matching when using quotes in BigQuery

### DIFF
--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -146,7 +146,8 @@ class HasColumnsMixin:
                     for test in test_values
                     if test.get("test_metadata", {})
                     .get("kwargs", {})
-                    .get("column_name")
+                    .get("column_name", "")
+                    .strip("`")
                     == name
                 ],
             )


### PR DESCRIPTION
I noticed the following issue in BigQuery, when using models where a column has "quote: true" defined.
In that case the data_tests defined for that column were not matched to that node. 
Consequently the test has_uniqueness_test failed.

When looking into the dbt manifest I saw that in the test node at test_metadata.kwargs.column_name the name contained the quotes (with grave accent `), e.g. 
`"column_name": "`my_column`"`
However at the model node it is always without the quotes, e.g.
```
"columns": {
  "my_column": {
    "name": "my_column"
```
