### PR TITLE
Fix filters being applied to wrong evaluables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Fix filters being applied to wrong evaluables (#124)
+
 ## [0.13.0] - 2025-07-07
 
 - Support linting of exposures (#112)

--- a/src/dbt_score/rule.py
+++ b/src/dbt_score/rule.py
@@ -166,12 +166,13 @@ class Rule:
         """
         resource_types_match = cls.resource_type is type(evaluable)
 
+        if not resource_types_match:
+            return False
+
         if cls.rule_filters:
-            return (
-                all(f.evaluate(evaluable) for f in cls.rule_filters)
-                and resource_types_match
-            )
-        return resource_types_match
+            return all(f.evaluate(evaluable) for f in cls.rule_filters)
+
+        return True
 
     @classmethod
     def set_severity(cls, severity: Severity) -> None:

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -145,7 +145,11 @@ class TestRuleFilterValidation:
 
     @pytest.mark.parametrize(
         "rule_filter_fixture",
-        ["source_filter_no_parens", "source_filter_parens", "source_filter_class"],
+        [
+            "source_filter_no_parens",
+            "source_filter_parens",
+            "source_filter_class",
+        ],
     )
     def test_rule_filter_must_match_resource_type_as_rule(
         self, request, rule_filter_fixture
@@ -174,3 +178,21 @@ class TestRuleFilterValidation:
 
         assert "Mismatched resource_type on filter" in str(excinfo.value)
         assert "Expected Model, but got Source" in str(excinfo.value)
+
+
+def test_should_evaluate(model1, source1):
+    """Test that Rule.should_evaluate works correctly for different resource types."""
+
+    @rule_filter
+    def model_filter(model: Model) -> bool:
+        """Filter on empty constraints."""
+        return model.constraints == []  # constraints does not exist for Source
+
+    @rule(rule_filters={model_filter()})
+    def model_rule(model: Model) -> RuleViolation | None:
+        """Rule that always returns None."""
+        return None
+
+    rule1 = model_rule()
+    assert rule1.should_evaluate(model1) is True
+    assert rule1.should_evaluate(source1) is False

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -181,7 +181,7 @@ class TestRuleFilterValidation:
 
 
 def test_should_evaluate(model1, source1):
-    """Test that Rule.should_evaluate works correctly for different resource types."""
+    """Test that should_evaluate does not execute filter on mismatched resource type."""
 
     @rule_filter
     def model_filter(model: Model) -> bool:


### PR DESCRIPTION
To check whether a rule should be evaluated, we executed all model filters even when the type of the evaluable filter did not match the evaluable.

To fix this; check the type first before executing the filters.