### PR TITLE
Display dbt parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Display the parse error message when `dbt parse` fails.
+
 ## [0.13.1] - 2025-07-29
 
 - Fix filters being applied to wrong evaluables (#124)

--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -166,7 +166,7 @@ def lint(  # noqa: PLR0912, PLR0913, C901
         ctx.exit(2)
 
     except DbtParseException as exc:
-        logger.error("dbt failed to parse project. %s", exc)
+        logger.error(exc)
         ctx.exit(2)
 
     except Exception:

--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -165,8 +165,8 @@ def lint(  # noqa: PLR0912, PLR0913, C901
         )
         ctx.exit(2)
 
-    except DbtParseException:
-        logger.error("dbt failed to parse project. Run `dbt parse` to investigate.")
+    except DbtParseException as exc:
+        logger.error("dbt failed to parse project. %s", exc)
         ctx.exit(2)
 
     except Exception:

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -29,9 +29,11 @@ class DbtParseException(Exception):
     def __str__(self) -> str:
         """Return a string representation of the exception."""
         if self.root_cause:
-            return f"\n\nRoot cause: {self.root_cause!s}"
+            return f"dbt parse failed.\n\nRoot cause: {self.root_cause!s}"
 
-        return "Root cause not found. Please run `dbt parse` manually."
+        return (
+            "dbt parse failed. Root cause not found. Please run `dbt parse` manually."
+        )
 
 
 class DbtLsException(Exception):

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -72,7 +72,7 @@ def dbt_parse() -> "dbtRunnerResult":
         result: "dbtRunnerResult" = dbtRunner().invoke(["parse"])
 
     if not result.success:
-        raise DbtParseException("dbt parse failed.", root_cause=None)
+        raise DbtParseException("dbt parse failed.", root_cause=result.exception)
 
     return result
 

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -21,6 +21,17 @@ class DbtNotInstalledException(Exception):
 class DbtParseException(Exception):
     """Raised when dbt parse fails."""
 
+    def __init__(self, message: str, root_cause: Any | None = None):
+        """Initialize the exception."""
+        super().__init__(message)
+        self.root_cause = root_cause
+
+    def __str__(self) -> str:
+        """Return a string representation of the exception."""
+        if self.root_cause:
+            return f"{self.args[0]}\n\nRoot cause: {self.root_cause!s}"
+        return str(self.args[0])
+
 
 class DbtLsException(Exception):
     """Raised when dbt ls fails."""
@@ -61,7 +72,7 @@ def dbt_parse() -> "dbtRunnerResult":
         result: "dbtRunnerResult" = dbtRunner().invoke(["parse"])
 
     if not result.success:
-        raise DbtParseException("dbt parse failed.") from result.exception
+        raise DbtParseException("dbt parse failed.", root_cause=None)
 
     return result
 

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -29,7 +29,7 @@ class DbtParseException(Exception):
     def __str__(self) -> str:
         """Return a string representation of the exception."""
         if self.root_cause:
-            return f"dbt parse failed.\n\nRoot cause: {self.root_cause!s}"
+            return f"dbt parse failed.\n\n{self.root_cause!s}"
 
         return (
             "dbt parse failed. Root cause not found. Please run `dbt parse` manually."

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -21,16 +21,17 @@ class DbtNotInstalledException(Exception):
 class DbtParseException(Exception):
     """Raised when dbt parse fails."""
 
-    def __init__(self, message: str, root_cause: Any | None = None):
+    def __init__(self, root_cause: Any | None = None):
         """Initialize the exception."""
-        super().__init__(message)
+        super().__init__()
         self.root_cause = root_cause
 
     def __str__(self) -> str:
         """Return a string representation of the exception."""
         if self.root_cause:
-            return f"{self.args[0]}\n\nRoot cause: {self.root_cause!s}"
-        return str(self.args[0])
+            return f"\n\nRoot cause: {self.root_cause!s}"
+
+        return "Root cause not found. Please run `dbt parse` manually."
 
 
 class DbtLsException(Exception):
@@ -72,7 +73,7 @@ def dbt_parse() -> "dbtRunnerResult":
         result: "dbtRunnerResult" = dbtRunner().invoke(["parse"])
 
     if not result.success:
-        raise DbtParseException("dbt parse failed.", root_cause=result.exception)
+        raise DbtParseException(root_cause=result.exception)
 
     return result
 

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -21,7 +21,7 @@ class DbtNotInstalledException(Exception):
 class DbtParseException(Exception):
     """Raised when dbt parse fails."""
 
-    def __init__(self, root_cause: Any | None = None):
+    def __init__(self, root_cause: Exception | None = None):
         """Initialize the exception."""
         super().__init__()
         self.root_cause = root_cause

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,10 +52,10 @@ def test_lint_dbt_parse_exception(caplog):
     runner = CliRunner()
 
     with patch("dbt_score.cli.dbt_parse") as mock_dbt_parse:
-        mock_dbt_parse.side_effect = DbtParseException("parsing error")
+        mock_dbt_parse.side_effect = DbtParseException()
         result = runner.invoke(lint, ["-p"], catch_exceptions=False)
     assert result.exit_code == 2
-    assert "dbt failed to parse project" in caplog.text
+    assert "dbt parse failed." in caplog.text
 
 
 def test_lint_dbt_not_installed(caplog, manifest_path):


### PR DESCRIPTION
When running dbt-score, if dbt parse fails, the error message does not reflect the root cause of the failure. This PR attaches the root cause to the DbtParseException object and prints it to the console.

Here’s an example of how it looks:

```shell
$ dbt-score lint -p

ERROR:dbt_score.cli:dbt failed to parse project. dbt parse failed.

Root cause: Compilation Error
  Model 'model.edge.example_incremental_model' (models/example_incremental_model/example_incremental_model.sql) depends on a node named 'example_overwrite_not_exists_model' which was not found
```