### PR TITLE
Feat/160 add exclude argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 - Expose column config field from the manifest.
 - Fix missing `json` in type annotations.
+- Add `--exclude` option to `dbt-score lint` to exclude dbt entities from
+  linting (#160).
 
 ## [0.15.0] - 2025-11-19
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ dbt-score lint --show all
 # Lint specific models
 dbt-score lint --select +my_model+
 
+# Exclude specific models
+dbt-score lint --exclude my_model+
+
 # Auto-generate manifest (via `dbt parse`) and lint
 dbt-score lint --run-dbt-parse
 ```
@@ -173,7 +176,7 @@ signal success or failure, making integrations a breeze!
 
 ### Selective Linting
 
-Use dbt's selection syntax to lint specific parts of projects:
+Use dbt's selection and/or exclusion syntax to lint specific parts of projects:
 
 ```bash
 # Lint only staging models
@@ -184,6 +187,9 @@ dbt-score lint --select +my_important_model
 
 # Lint recently changed models
 dbt-score lint --select state:modified
+
+# Lint all models except experimental ones
+dbt-score lint --exclude my_experimental_model+
 ```
 
 ## Documentation

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -48,6 +48,20 @@ It accepts any
 dbt-score lint --select +my_model+
 ```
 
+To exclude specific dbt entities from linting, the argument `--exclude` can be
+used. It also accepts any
+[dbt node exclusion syntax](https://docs.getdbt.com/reference/node-selection/exclude):
+
+```shell
+dbt-score lint --exclude my_model+
+```
+
+Both `--select` and `--exclude` can be combined:
+
+```shell
+dbt-score lint --select +my_model+ --exclude my_model+
+```
+
 To get more information on how to run `dbt-score`, `--help` can be used:
 
 ```shell

--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -124,8 +124,8 @@ def cli() -> None:
 def lint(  # noqa: PLR0912, PLR0913, C901
     ctx: click.Context,
     format: Literal["plain", "manifest", "ascii", "json"],
-    select: tuple[str],
-    exclude: tuple[str],
+    select: tuple[str, ...],
+    exclude: tuple[str, ...],
     namespace: list[str],
     disabled_rule: list[str],
     manifest: Path,

--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -54,6 +54,12 @@ def cli() -> None:
     multiple=True,
 )
 @click.option(
+    "--exclude",
+    "-e",
+    help="Specify the nodes to exclude.",
+    multiple=True,
+)
+@click.option(
     "--namespace",
     "-n",
     help="Namespace to look for rules.",
@@ -119,6 +125,7 @@ def lint(  # noqa: PLR0912, PLR0913, C901
     ctx: click.Context,
     format: Literal["plain", "manifest", "ascii", "json"],
     select: tuple[str],
+    exclude: tuple[str],
     namespace: list[str],
     disabled_rule: list[str],
     manifest: Path,
@@ -155,7 +162,11 @@ def lint(  # noqa: PLR0912, PLR0913, C901
         if run_dbt_parse:
             dbt_parse()
         evaluation = lint_dbt_project(
-            manifest_path=manifest, config=config, format=format, select=select
+            manifest_path=manifest,
+            config=config,
+            format=format,
+            select=select,
+            exclude=exclude,
         )
 
     except FileNotFoundError:

--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -81,7 +81,9 @@ def dbt_parse() -> "dbtRunnerResult":
 
 
 @dbt_required
-def dbt_ls(select: Iterable[str] | None) -> Iterable[str]:
+def dbt_ls(
+    select: Iterable[str] | None, exclude: Iterable[str] | None = None
+) -> Iterable[str]:
     """Run dbt ls."""
     cmd = [
         "ls",
@@ -96,6 +98,8 @@ def dbt_ls(select: Iterable[str] | None) -> Iterable[str]:
     ]
     if select:
         cmd += ["--select", *select]
+    if exclude:
+        cmd += ["--exclude", *exclude]
 
     with _disable_dbt_stdout():
         result: "dbtRunnerResult" = dbtRunner().invoke(cmd)

--- a/src/dbt_score/lint.py
+++ b/src/dbt_score/lint.py
@@ -19,6 +19,7 @@ def lint_dbt_project(
     config: Config,
     format: Literal["plain", "manifest", "ascii", "json"],
     select: Iterable[str] | None = None,
+    exclude: Iterable[str] | None = None,
 ) -> Evaluation:
     """Lint dbt manifest."""
     if not manifest_path.exists():
@@ -27,7 +28,7 @@ def lint_dbt_project(
     rule_registry = RuleRegistry(config)
     rule_registry.load_all()
 
-    manifest_loader = ManifestLoader(manifest_path, select=select)
+    manifest_loader = ManifestLoader(manifest_path, select=select, exclude=exclude)
 
     formatters = {
         "plain": HumanReadableFormatter,

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -859,11 +859,13 @@ class ManifestLoader:
         """Filter evaluables like dbt's --select and --exclude."""
         single_model_select = re.compile(r"[a-zA-Z0-9_]+")
 
-        if not select and not exclude:
-            return
-
+        # Re-reading an Iterable can exhaust generators.
+        # Materialize here
         selected_set = set(select or [])
         excluded_set = set(exclude or [])
+
+        if not select and not exclude:
+            return
 
         if all(
             single_model_select.fullmatch(x) for x in selected_set.union(excluded_set)

--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -707,12 +707,18 @@ Evaluable: TypeAlias = Model | Source | Snapshot | Seed | Exposure | Macro
 class ManifestLoader:
     """Load the evaluables from the manifest."""
 
-    def __init__(self, file_path: Path, select: Iterable[str] | None = None):
+    def __init__(
+        self,
+        file_path: Path,
+        select: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
+    ):
         """Initialize the ManifestLoader.
 
         Args:
             file_path: The file path of the JSON manifest.
             select: An optional dbt selection.
+            exclude: An optional dbt exclusion.
         """
         self.raw_manifest = json.loads(file_path.read_text(encoding="utf-8"))
         self.project_name = self.raw_manifest["metadata"]["project_name"]
@@ -756,8 +762,7 @@ class ManifestLoader:
         self._load_macros()
         self._populate_relatives()
 
-        if select:
-            self._filter_evaluables(select)
+        self._filter_evaluables(select, exclude)
 
         if (
             len(self.models)
@@ -848,23 +853,46 @@ class ManifestLoader:
                     node.parents.append(self.seeds[parent_id])
                     self.seeds[parent_id].children.append(node)
 
-    def _filter_evaluables(self, select: Iterable[str]) -> None:
-        """Filter evaluables like dbt's --select."""
+    def _filter_evaluables(
+        self, select: Iterable[str] | None, exclude: Iterable[str] | None
+    ) -> None:
+        """Filter evaluables like dbt's --select and --exclude."""
         single_model_select = re.compile(r"[a-zA-Z0-9_]+")
 
-        if all(single_model_select.fullmatch(x) for x in select):
-            # Using '--select my_model' is a common case, which can easily be sped up by
-            # not invoking dbt
-            selected = select
-        else:
-            # Use dbt's implementation of --select
-            selected = dbt_ls(select)
+        if not select and not exclude:
+            return
 
-        self.models = {k: m for k, m in self.models.items() if m.name in selected}
+        selected_set = set(select or [])
+        excluded_set = set(exclude or [])
+
+        if all(
+            single_model_select.fullmatch(x) for x in selected_set.union(excluded_set)
+        ):
+            # All tokens are simple names — filter in-memory without invoking dbt
+            available = (
+                {model.name for model in self.models.values()}
+                | {source.selector_name for source in self.sources.values()}
+                | {snapshot.name for snapshot in self.snapshots.values()}
+                | {exposure.name for exposure in self.exposures.values()}
+                | {seed.name for seed in self.seeds.values()}
+                | {macro.name for macro in self.macros.values()}
+            )
+
+            result_list = list((selected_set or available) - excluded_set)
+
+        else:
+            # Use dbt's implementation of --select and --exclude
+            result_list = dbt_ls(select, exclude)
+
+        self.models = {k: m for k, m in self.models.items() if m.name in result_list}
         self.sources = {
-            k: s for k, s in self.sources.items() if s.selector_name in selected
+            k: s for k, s in self.sources.items() if s.selector_name in result_list
         }
-        self.snapshots = {k: s for k, s in self.snapshots.items() if s.name in selected}
-        self.exposures = {k: e for k, e in self.exposures.items() if e.name in selected}
-        self.seeds = {k: s for k, s in self.seeds.items() if s.name in selected}
-        self.macros = {k: m for k, m in self.macros.items() if m.name in selected}
+        self.snapshots = {
+            k: s for k, s in self.snapshots.items() if s.name in result_list
+        }
+        self.exposures = {
+            k: e for k, e in self.exposures.items() if e.name in result_list
+        }
+        self.seeds = {k: s for k, s in self.seeds.items() if s.name in result_list}
+        self.macros = {k: m for k, m in self.macros.items() if m.name in result_list}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,27 @@ def raw_manifest(manifest_path) -> Any:
 
 
 @fixture
+def chain_manifest_path() -> Path:
+    """Return the path of a chain manifest.
+
+    This manifest contains a chain of models with dependencies, depicted using
+    arrows below:
+
+    model0->model1->model2->model3
+
+    It also contains a standalone model with no dependencies:
+    standalone
+    """
+    return Path(__file__).parent / "resources" / "manifest_chain.json"
+
+
+@fixture
+def chain_raw_manifest(chain_manifest_path) -> Any:
+    """Return a raw chain manifest."""
+    return json.loads(chain_manifest_path.read_text(encoding="utf-8"))
+
+
+@fixture
 def manifest_loader(manifest_path) -> ManifestLoader:
     """Return an instantiated and loaded manifest loader."""
     return ManifestLoader(file_path=manifest_path)

--- a/tests/resources/manifest_chain.json
+++ b/tests/resources/manifest_chain.json
@@ -1,0 +1,170 @@
+{
+  "metadata": {
+    "project_name": "package"
+  },
+  "nodes": {
+    "model.package.model0": {
+      "resource_type": "model",
+      "unique_id": "model.package.model0",
+      "name": "model0",
+      "relation_name": "database.schema.model0",
+      "description": "",
+      "original_file_path": "/path/to/model0.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "constraints": [],
+      "package_name": "package",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT 1",
+      "alias": "model0",
+      "patch_path": null,
+      "tags": [],
+      "depends_on": { "nodes": [] },
+      "language": "sql",
+      "access": "protected",
+      "group": null
+    },
+    "model.package.model1": {
+      "resource_type": "model",
+      "unique_id": "model.package.model1",
+      "name": "model1",
+      "relation_name": "database.schema.model1",
+      "description": "",
+      "original_file_path": "/path/to/model1.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "constraints": [],
+      "package_name": "package",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT 1",
+      "alias": "model1",
+      "patch_path": null,
+      "tags": [],
+      "depends_on": { "nodes": ["model.package.model0"] },
+      "language": "sql",
+      "access": "protected",
+      "group": null
+    },
+    "model.package.model2": {
+      "resource_type": "model",
+      "unique_id": "model.package.model2",
+      "name": "model2",
+      "relation_name": "database.schema.model2",
+      "description": "",
+      "original_file_path": "/path/to/model2.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "constraints": [],
+      "package_name": "package",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT 1",
+      "alias": "model2",
+      "patch_path": null,
+      "tags": [],
+      "depends_on": { "nodes": ["model.package.model1"] },
+      "language": "sql",
+      "access": "protected",
+      "group": null
+    },
+    "model.package.model3": {
+      "resource_type": "model",
+      "unique_id": "model.package.model3",
+      "name": "model3",
+      "relation_name": "database.schema.model3",
+      "description": "",
+      "original_file_path": "/path/to/model3.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "constraints": [],
+      "package_name": "package",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT 1",
+      "alias": "model3",
+      "patch_path": null,
+      "tags": [],
+      "depends_on": { "nodes": ["model.package.model2"] },
+      "language": "sql",
+      "access": "protected",
+      "group": null
+    },
+    "model.package.standalone": {
+      "resource_type": "model",
+      "unique_id": "model.package.standalone",
+      "name": "standalone",
+      "relation_name": "database.schema.standalone",
+      "description": "",
+      "original_file_path": "/path/to/standalone.sql",
+      "config": {},
+      "meta": {},
+      "columns": {
+        "a": {
+          "name": "column_a",
+          "description": "Column A.",
+          "data_type": "string",
+          "meta": {},
+          "constraints": [],
+          "tags": []
+        }
+      },
+      "constraints": [],
+      "package_name": "package",
+      "database": "db",
+      "schema": "schema",
+      "raw_code": "SELECT 1",
+      "alias": "standalone",
+      "patch_path": null,
+      "tags": [],
+      "depends_on": { "nodes": [] },
+      "language": "sql",
+      "access": "protected",
+      "group": null
+    }
+  },
+  "sources": {},
+  "exposures": {},
+  "macros": {}
+}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -126,7 +126,7 @@ def test_manifest_select_models_dbt_ls(mock_dbt_ls, mock_read_text, raw_manifest
         manifest_loader = ManifestLoader(Path("some.json"), select=["+model1"])
 
     assert [x.name for x in manifest_loader.models.values()] == ["model1"]
-    mock_dbt_ls.assert_called_once_with(["+model1"])
+    mock_dbt_ls.assert_called_once_with(["+model1"], None)
 
 
 @patch("dbt_score.models.Path.read_text")
@@ -138,3 +138,125 @@ def test_manifest_no_model(mock_dbt_ls, mock_read_text, raw_manifest, caplog):
 
     assert len(manifest_loader.models) == 0
     assert "Nothing to evaluate!" in caplog.text
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_exclude_simple(mock_dbt_ls, mock_read_text, chain_raw_manifest):
+    """Exclude model1 — model1 is excluded, the rest are included."""
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(Path("some.json"), exclude=["model1"])
+
+    assert sorted(m.name for m in loader.models.values()) == sorted(
+        ["model0", "model2", "model3", "standalone"]
+    )
+    mock_dbt_ls.assert_not_called()
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_exclude_ancestors(mock_dbt_ls, mock_read_text, chain_raw_manifest):
+    """Exclude +model1 — model0 and model1 are excluded, the rest are included."""
+    mock_dbt_ls.return_value = ["model2", "model3", "standalone"]
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(Path("some.json"), exclude=["+model1"])
+
+    assert sorted(m.name for m in loader.models.values()) == sorted(
+        ["model2", "model3", "standalone"]
+    )
+    mock_dbt_ls.assert_called_once_with(None, ["+model1"])
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_exclude_descendants(mock_dbt_ls, mock_read_text, chain_raw_manifest):
+    """Exclude model1+ — model0 and standalone are kept.
+
+    model1, model2 and model3 are descendants of model1 (or model1 itself), so excluded.
+    """
+    mock_dbt_ls.return_value = ["model0", "standalone"]
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(Path("some.json"), exclude=["model1+"])
+
+    assert sorted(m.name for m in loader.models.values()) == sorted(
+        ["model0", "standalone"]
+    )
+    mock_dbt_ls.assert_called_once_with(None, ["model1+"])
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_exclude_non_existing(mock_dbt_ls, mock_read_text, chain_raw_manifest):
+    """Exclude non_existing — all models are included since the model does not exist."""
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(Path("some.json"), exclude=["non_existing"])
+
+    assert sorted(m.name for m in loader.models.values()) == sorted(
+        ["model0", "model1", "model2", "model3", "standalone"]
+    )
+    mock_dbt_ls.assert_not_called()
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_select_and_exclude_simple(
+    mock_dbt_ls, mock_read_text, chain_raw_manifest
+):
+    """Select model2 and exclude model1 — only model2 is included."""
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(
+            Path("some.json"), select=["model2"], exclude=["model1"]
+        )
+
+    assert [m.name for m in loader.models.values()] == ["model2"]
+    mock_dbt_ls.assert_not_called()
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_select_and_exclude_same_model(
+    mock_dbt_ls, mock_read_text, chain_raw_manifest
+):
+    """Select model1 and exclude model1 — no models are included."""
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(
+            Path("some.json"), select=["model1"], exclude=["model1"]
+        )
+
+    assert len(loader.models) == 0
+    mock_dbt_ls.assert_not_called()
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_select_and_exclude_ancestors_complex(
+    mock_dbt_ls, mock_read_text, chain_raw_manifest
+):
+    """Select +model1 and exclude +model1 — no models are included."""
+    mock_dbt_ls.return_value = []
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(
+            Path("some.json"), select=["+model1"], exclude=["+model1"]
+        )
+
+    assert len(loader.models) == 0
+    mock_dbt_ls.assert_called_once()
+
+
+@patch("dbt_score.models.Path.read_text")
+@patch("dbt_score.models.dbt_ls")
+def test_manifest_select_simple_exclude_descendants(
+    mock_dbt_ls, mock_read_text, chain_raw_manifest
+):
+    """Select model2 and exclude model1+ — no models included.
+
+    model2 is a descendant of model1, so it is excluded.
+    """
+    mock_dbt_ls.return_value = []
+    with patch("dbt_score.models.json.loads", return_value=chain_raw_manifest):
+        loader = ManifestLoader(
+            Path("some.json"), select=["model2"], exclude=["model1+"]
+        )
+
+    assert len(loader.models) == 0
+    mock_dbt_ls.assert_called_once()


### PR DESCRIPTION
Closes #160 

Currently, the --select argument is available, to select the models on which to run dbt-score lint:
```
dbt-score lint --select +my_model+
```

This PR introduces the --exclude argument to exclude models on which we don't want to run dbt-score lint:
```
dbt-score lint --exclude my_experimental_model+
```