### PR TITLE
fix: Fix Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,7 @@ jobs:
         run: |
           uv sync --locked --only-dev
       - name: Run Prettier
-        uses: creyD/prettier_action@v4.3
-        with:
-          dry: True
-          prettier_options: "--check **/*.{json,yaml,yml,md}"
+        run: npx --yes prettier --check "**/*.{json,yaml,yml,md}"
       - name: Run Tox
         run: |
           uv run tox -e py,lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -57,7 +58,7 @@ jobs:
         run: |
           uv sync --locked --only-dev
       - name: Run Prettier
-        run: npx --yes prettier --check "**/*.{json,yaml,yml,md}"
+        run: npx --yes prettier@3.1.0 --check "**/*.{json,yaml,yml,md}"
       - name: Run Tox
         run: |
           uv run tox -e py,lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app
         continue-on-error: true
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:
@@ -36,7 +36,7 @@ jobs:
             github.repository }}
           token: ${{ steps.app.outputs.token || github.token }}
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           python-version: ${{ matrix.python }}
       # refresh lock only for Dependabot PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           python-version: 3.13
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           uv run dbt-score list -f markdown -n dbt_score.rules.generic --title Generic > docs/rules/generic.md
           uv run dbt-score list -f markdown -n dbt_score.rules.macros --title Macros > docs/rules/macros.md
           uv run mkdocs gh-deploy --force
-      - uses: ncipollo/release-action@v1
-        with:
-          generateReleaseNotes: true
+      - name: Create GitHub release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           python-version: 3.13
+          enable-cache: false
       - name: Build
         run: uv build
       - name: Publish package distributions to PyPI
@@ -33,6 +34,7 @@ jobs:
           uv run dbt-score list -f markdown -n dbt_score.rules.macros --title Macros > docs/rules/macros.md
           uv run mkdocs gh-deploy --force
       - name: Create GitHub release
-        run: gh release create "${{ github.ref_name }}" --generate-notes
+        run: gh release create "$TAG" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}


### PR DESCRIPTION
After some org-wide security policy changes, we fix the Github Actions by:
- Pinning the version to a specific SHA 📍
- Changing some third-party actions to homegrown CLI commands 🌱

This PR mirrors the current behavior of our Github Actions. In a future PR, we can consider upgrading the versions.