### PR TITLE
Add downstream_count attribute via BFS DAG traversal

### DIFF
--- a/src/dbt_score/models.py
+++ b/src/dbt_score/models.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import re
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Literal, TypeAlias, Union
@@ -264,6 +264,35 @@ class Model(HasColumnsMixin):
     def __hash__(self) -> int:
         """Compute a unique hash for a model."""
         return hash(self.unique_id)
+
+    @property
+    def downstream_count(self) -> int:
+        """Calculate the count of all downstream model dependents.
+
+        Returns:
+            int: The count of unique downstream models.
+        """
+        visited: set[str] = set()
+        queue: deque[ChildType] = deque()
+        for child in self.children:
+            if child.unique_id not in visited:
+                visited.add(child.unique_id)
+                queue.append(child)
+
+        count = 0
+        while queue:
+            current = queue.popleft()
+
+            if isinstance(current, Model):
+                count += 1
+
+            if hasattr(current, "children"):
+                for grandchild in current.children:
+                    if grandchild.unique_id not in visited:
+                        visited.add(grandchild.unique_id)
+                        queue.append(grandchild)
+
+        return count
 
 
 @dataclass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from dbt_score.models import ManifestLoader
+from dbt_score.models import Exposure, ManifestLoader, Model, Snapshot
 
 
 @patch("dbt_score.models.Path.read_text")
@@ -260,3 +260,129 @@ def test_manifest_select_simple_exclude_descendants(
 
     assert len(loader.models) == 0
     mock_dbt_ls.assert_called_once()
+
+
+def create_dummy_model(unique_id: str, name: str = "dummy", children=None) -> Model:
+    """Helper to create a minimal Model instance for testing."""
+    return Model(
+        unique_id=unique_id,
+        name=name,
+        relation_name="relation",
+        description="desc",
+        original_file_path="path.sql",
+        config={},
+        meta={},
+        columns=[],
+        package_name="pkg",
+        database="db",
+        schema="schema",
+        raw_code="select 1",
+        language="sql",
+        access="public",
+        group="group",
+        parents=[],
+        children=children or [],
+    )
+
+
+def create_dummy_snapshot(
+    unique_id: str, name: str = "dummy", children=None
+) -> Snapshot:
+    """Helper to create a minimal Snapshot instance for testing."""
+    return Snapshot(
+        unique_id=unique_id,
+        name=name,
+        relation_name="relation",
+        description="desc",
+        original_file_path="path.sql",
+        config={},
+        meta={},
+        columns=[],
+        package_name="pkg",
+        database="db",
+        schema="schema",
+        raw_code="select 1",
+        language="sql",
+        parents=[],
+        children=children or [],
+    )
+
+
+def create_dummy_exposure(unique_id: str, name: str = "dummy") -> Exposure:
+    """Helper to create a minimal Exposure instance for testing."""
+    return Exposure(
+        unique_id=unique_id,
+        name=name,
+        description="desc",
+        label="label",
+        url="http://url",
+        maturity="high",
+        original_file_path="path.yml",
+        type="dashboard",
+        owner={},
+        config={},
+        meta={},
+        tags=[],
+        parents=[],
+    )
+
+
+def test_downstream_count_isolated():
+    """Verify that a standalone model with no children/dependents returns 0."""
+    model = create_dummy_model("model.package.isolated", "isolated")
+    assert model.downstream_count == 0
+
+
+def test_downstream_count_single_child():
+    """Verify that a model with exactly one child model returns 1."""
+    child = create_dummy_model("model.package.child", "child")
+    parent = create_dummy_model("model.package.parent", "parent", children=[child])
+    assert parent.downstream_count == 1
+
+
+def test_downstream_count_linear_chain():
+    """Verify downstream_count calculation in a linear chain of dependencies."""
+    grandchild = create_dummy_model("model.package.grandchild", "grandchild")
+    child = create_dummy_model("model.package.child", "child", children=[grandchild])
+    parent = create_dummy_model("model.package.parent", "parent", children=[child])
+    assert parent.downstream_count == 2
+    assert child.downstream_count == 1
+
+
+def test_downstream_count_diamond_dag():
+    """Verify downstream_count in a diamond dependency.
+
+    Ensure the shared descendant is only counted once.
+    """
+    descendant = create_dummy_model("model.package.descendant", "descendant")
+    child_b = create_dummy_model(
+        "model.package.child_b", "child_b", children=[descendant]
+    )
+    child_c = create_dummy_model(
+        "model.package.child_c", "child_c", children=[descendant]
+    )
+    parent = create_dummy_model(
+        "model.package.parent", "parent", children=[child_b, child_c]
+    )
+    assert parent.downstream_count == 3
+
+
+def test_downstream_count_with_non_model_descendants():
+    """Verify only Model instances are counted.
+
+    Ensure non-model nodes are traversed correctly.
+    """
+    exposure = create_dummy_exposure("exposure.package.exp")
+    snapshot = create_dummy_snapshot(
+        "snapshot.package.snap", "snap", children=[exposure]
+    )
+    model = create_dummy_model("model.package.m", "m")
+
+    # Snapshot (not Model) has exposure (not Model) and model (Model)
+    snapshot.children.append(model)
+
+    # Root model has snapshot
+    parent = create_dummy_model("model.package.parent", "parent", children=[snapshot])
+
+    # Only model should be counted (1), snapshot and exposure are not Model type
+    assert parent.downstream_count == 1


### PR DESCRIPTION
## Summary

Adds a `downstream_count` property to `Model`, computed via BFS over the DAG.

This is Step 1 of the proposal in #184.

## Context

From the discussion in #184, I said:

> Step 1: Expose downstream_count on Model
> A computed attribute derived from a single BFS pass over the loaded manifest, counting direct + transitive descendants. Small, standalone, and immediately useful for anyone writing custom rules (e.g., "flag any high fan-out model without a contract").

This PR is that follow-up implemented, tested against synthetic DAG structures, and validated against a real dbt manifest.

## Changes

- `src/dbt_score/models.py`: new `downstream_count` property on `Model`, BFS traversal over `children`, deduped via a visited set (handles diamond-shaped DAGs without double-counting).
- `tests/test_models.py`: 5 new test cases (isolated model, single child, linear chain, diamond DAG, non-Model descendants).

## Testing

- `uv run pytest` - 129 passed
- `uv run mypy .` - clean on touched files (1 pre-existing, unrelated error in `dbt_utils.py`)
- `uv run ruff check .` - clean

Validated against a real dbt manifest (`dbt-labs/jaffle_shop_duckdb`) and cross-checked independently against `dbt ls --select <model>+`:

| Model | downstream_count | dbt ls --select <model>+ (minus itself) |
|---|---|---|
| customers | 0 | 0 |
| orders | 0 | 0 |
| stg_customers | 1 | 1 |
| stg_orders | 2 | 2 |
| stg_payments | 2 | 2 |

All values match independently, confirming the BFS traversal and dedup logic behave correctly against a real manifest, not just synthetic test fixtures.

## Notes

Part of #184 - Step 4 (high-fan-out contract rule) will follow as a separate PR once this lands, since it depends on this attribute.