### PR TITLE
docs: fix exit-code typo in programmatic invocations

### DIFF
--- a/docs/programmatic_invocations.md
+++ b/docs/programmatic_invocations.md
@@ -56,7 +56,7 @@ $ dbt-score lint --format json
 
 ## Exit codes
 
-When `dbt-score` terminates, it exists with one of the following exit codes:
+When `dbt-score` terminates, it exits with one of the following exit codes:
 
 - `0` in case of successful termination. This is the happy case, when the
   project being linted either doesn't raise any warning, or the warnings are


### PR DESCRIPTION
## What changed

Fixed a typo in `docs/programmatic_invocations.md`: "it exists with" → "it exits with".

## How to review

- One-line diff; just read it.
- Optionally run `uv run mkdocs build` to confirm docs still build.