### PR TITLE
ci: let Dependabot manage GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     commit-message:
       prefix: "deps"
     versioning-strategy: increase
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 25
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
## What changed

Added a `github-actions` ecosystem entry to `.github/dependabot.yml`.

The workflow actions are SHA-pinned. Dependabot supports (and recommends) SHA
pinning: it bumps the pinned SHA and includes the human-readable version in the
PR. Previously only the `pip` ecosystem was monitored, so pinned actions never
received security/version updates.

The new entry mirrors the existing `pip` entry's cadence (`monthly`) and commit
prefix (`deps`).

## How to review

- Validate the YAML structure against the [Dependabot schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file): two `updates` entries (`pip` + `github-actions`).
- Confirm cadence and `deps` commit prefix match the existing entry.
- Human input: after merge, watch for the first Dependabot Actions PR to confirm
  it targets the right directory (`/`) and updates SHAs as expected.