### PR TITLE
fix: make dbt conditional-import type-ignore robust

### DIFF
--- a/src/dbt_score/dbt_utils.py
+++ b/src/dbt_score/dbt_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, Iterator, cast
 # Conditionally import dbt objects.
 try:
     DBT_INSTALLED = True
-    from dbt.cli.main import (  # type: ignore[import-not-found]
+    from dbt.cli.main import (  # type: ignore[import-not-found, unused-ignore]
         dbtRunner,
         dbtRunnerResult,
     )


### PR DESCRIPTION
## What changed

`src/dbt_score/dbt_utils.py` imports the optional `dbt` dependency inside a
`try/except ImportError`, using `# type: ignore[import-not-found]`. When dbt *is*
installed (e.g. local dev, or any environment with dbt present), mypy's
`warn_unused_ignores` (enabled by `strict`) flags that ignore as unused, causing
a spurious failure.

Added `unused-ignore` to the codes:

```python
from dbt.cli.main import (  # type: ignore[import-not-found, unused-ignore]
```

This is the canonical pattern for optional imports — it is correct whether or not
dbt is installed:
- dbt absent → `import-not-found` is active; `unused-ignore` is a harmless no-op.
- dbt present → the now-unused `import-not-found` is suppressed by `unused-ignore`.

## How to review

- With dbt installed, run `uv run mypy .` — previously errored on
  `dbt_utils.py:12`, now clean.
- Note: CI's lint env does not install dbt (`lint`/`test` groups only), so this
  was not caught there. Reviewers can reproduce by installing `dbt-core` locally
  and running mypy.