### PR TITLE
fix: honor a threshold of 0 for --fail-project-under / --fail-any-item-under

### DIFF
--- a/src/dbt_score/cli.py
+++ b/src/dbt_score/cli.py
@@ -130,8 +130,8 @@ def lint(  # noqa: PLR0913, C901
     disabled_rule: list[str],
     manifest: Path,
     run_dbt_parse: bool,
-    fail_project_under: float,
-    fail_any_item_under: float,
+    fail_project_under: float | None,
+    fail_any_item_under: float | None,
     show: Literal["all", "failing-items", "failing-rules"],
     debug: bool,
 ) -> None:
@@ -149,9 +149,9 @@ def lint(  # noqa: PLR0913, C901
         config.overload({"rule_namespaces": namespace})
     if disabled_rule:
         config.overload({"disabled_rules": disabled_rule})
-    if fail_project_under:
+    if fail_project_under is not None:
         config.overload({"fail_project_under": fail_project_under})
-    if fail_any_item_under:
+    if fail_any_item_under is not None:
         config.overload({"fail_any_item_under": fail_any_item_under})
     if show:
         config.overload({"show": show})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,3 +130,30 @@ def test_fail_any_item_under(manifest_path):
 
         # Since we're mocking the evaluation with a low score, we should get exit code 1
         assert result.exit_code == 1
+
+
+def test_lint_fail_thresholds_zero(manifest_path):
+    """A threshold of 0 is honored (not treated as unset)."""
+    mock_eval = MagicMock()
+    mock_eval.project_score = Score(0.0, "🚧")
+    mock_eval.scores = {MagicMock(): Score(0.0, "🚧")}
+
+    with (
+        patch("dbt_score.cli.lint_dbt_project") as mock_lint,
+        patch("dbt_score.cli.Config._load_toml_file"),
+    ):
+        mock_lint.return_value = mock_eval
+        runner = CliRunner()
+        result = runner.invoke(
+            lint,
+            [
+                "--manifest",
+                manifest_path,
+                "--fail-project-under",
+                "0",
+                "--fail-any-item-under",
+                "0",
+            ],
+        )
+    # With thresholds at 0 and scores at 0, nothing is strictly under -> pass.
+    assert result.exit_code == 0


### PR DESCRIPTION
## What changed

`dbt-score lint` silently ignored `--fail-project-under 0` and
`--fail-any-item-under 0`. The CLI used a truthiness check
(`if fail_project_under:`) to decide whether to apply the override, and since `0`
is falsy the value was dropped and the default (`5.0`) was used instead.

Changed the checks to `is not None`, so an explicit `0` (a valid threshold) is
respected. Added a regression test.

Files: `src/dbt_score/cli.py`, `tests/test_cli.py`.

## How to review

- Confirm the `is not None` logic is correct for all option combinations
  (default unset vs. `0` vs. positive values).
- Run the regression test:
  ```shell
  uv run pytest tests/test_cli.py -k fail_thresholds_zero
  ```
- Manual sanity check: `dbt-score lint --fail-project-under 0 ...` on a project
  should no longer fail purely due to the default 5.0 threshold.
- Human input: confirm the intended semantics — `0` should be a valid, honored
  threshold.