### PR TITLE
test: update test matrix to only combine supported python and dbt versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,24 @@ jobs:
   build:
     runs-on: ubuntu-slim
     strategy:
+      fail-fast: false
+      # NOTE: This matrix duplicates the supported Python/dbt-core combinations
+      # defined in tox.ini's `env_list`. If you add or drop a Python or dbt
+      # version, update BOTH files. The valid combinations follow dbt's Python
+      # compatibility matrix:
+      # https://docs.getdbt.com/faqs/Core/install-python-compatibility
+      #   dbt 1.5/1.6:   Python 3.10-3.11
+      #   dbt 1.7:       Python 3.10-3.12
+      #   dbt 1.10/1.11: Python 3.10-3.13
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
         dbt-core: ["15", "16", "17", "110", "111"]
+        exclude:
+          - { python: "3.12", dbt-core: "15" }
+          - { python: "3.12", dbt-core: "16" }
+          - { python: "3.13", dbt-core: "15" }
+          - { python: "3.13", dbt-core: "16" }
+          - { python: "3.13", dbt-core: "17" }
 
     steps:
       - name: Create GitHub App Token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       # compatibility matrix:
       # https://docs.getdbt.com/faqs/Core/install-python-compatibility
       #   dbt 1.5/1.6:   Python 3.10-3.11
-      #   dbt 1.7:       Python 3.10-3.12
-      #   dbt 1.10/1.11: Python 3.10-3.13
+      #   dbt 1.7/1.19:  Python 3.10-3.12
+      #   dbt 1.11:      Python 3.10-3.13
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
         dbt-core: ["15", "16", "17", "110", "111"]
@@ -35,6 +35,7 @@ jobs:
           - { python: "3.13", dbt-core: "15" }
           - { python: "3.13", dbt-core: "16" }
           - { python: "3.13", dbt-core: "17" }
+          - { python: "3.13", dbt-core: "110" }
 
     steps:
       - name: Create GitHub App Token

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,15 @@
 [tox]
-env_list = py{310,311,312,313}-dbt{15,16,17,110,111},lint,docs
+# Only officially supported Python/dbt-core combinations are listed here.
+#   dbt 1.5/1.6:   Python 3.10-3.11
+#   dbt 1.7:       Python 3.10-3.12
+#   dbt 1.10/1.11: Python 3.10-3.13
+# See https://docs.getdbt.com/faqs/Core/install-python-compatibility
+env_list =
+    py{310,311}-dbt{15,16,17,110,111}
+    py312-dbt{17,110,111}
+    py313-dbt{110,111}
+    lint
+    docs
 
 skip_missing_interpreters = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 # Only officially supported Python/dbt-core combinations are listed here.
 #   dbt 1.5/1.6:   Python 3.10-3.11
-#   dbt 1.7:       Python 3.10-3.12
-#   dbt 1.10/1.11: Python 3.10-3.13
+#   dbt 1.7/1.19:  Python 3.10-3.12
+#   dbt 1.11:      Python 3.10-3.13
 # See https://docs.getdbt.com/faqs/Core/install-python-compatibility
 env_list =
     py{310,311}-dbt{15,16,17,110,111}
     py312-dbt{17,110,111}
-    py313-dbt{110,111}
+    py313-dbt111
     lint
     docs
 


### PR DESCRIPTION
Not all dbt version x python versions are [officially supported](https://docs.getdbt.com/faqs/Core/install-python-compatibility). While all tests still used to pass, in some tests in https://github.com/PicnicSupermarket/dbt-score/pull/194 these unsupported combinations started failing. Therefore, update the matrix to only combine supported versions.

I've decided to duplicate the matrix in `ci.yml` and `tox.ini`. We could do some magic to have only the env list in `tox.ini`, but it was a bit too much magic for my tastes. Instead: add a comment to `ci.yml` indicating this duplication.