### PR TITLE
Sign uv-bot commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,20 @@ jobs:
           github.event_name == 'pull_request' &&
           github.actor == 'dependabot[bot]'
         env:
-          GH_TOKEN: ${{ steps.app.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "App token unavailable, refusing to refresh uv.lock as a different identity" >&2
+            exit 1
+          fi
+
           uv lock
           if git diff --quiet -- uv.lock; then
             exit 0
           fi
 
-          REPO="${{ github.repository }}"
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           SHA=$(gh api "/repos/$REPO/contents/uv.lock?ref=$BRANCH" --jq .sha)
 
           gh api --method PUT "/repos/$REPO/contents/uv.lock" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,28 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  refresh-lock:
     runs-on: ubuntu-slim
-    strategy:
-      matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
-        dbt-core: ["15", "16", "17", "110", "111"]
-
+    if: |
+      github.event_name == 'pull_request' &&
+      github.actor == 'dependabot[bot]'
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app
-        continue-on-error: true
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
-          repository:
-            ${{ github.event.pull_request.head.repo.full_name ||
-            github.repository }}
-          token: ${{ steps.app.outputs.token || github.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install uv and set the Python version
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          python-version: ${{ matrix.python }}
-      # refresh lock only for Dependabot PRs
-      - name: Refresh uv.lock (Dependabot only)
-        if: |
-          github.event_name == 'pull_request' &&
-          github.actor == 'dependabot[bot]'
+          python-version: "3.13"
+      - name: Refresh uv.lock
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           REPO: ${{ github.repository }}
@@ -68,6 +58,29 @@ jobs:
             -f content="$(base64 -w0 uv.lock)" \
             -f branch="$BRANCH" \
             -f sha="$SHA"
+
+  build:
+    needs: refresh-lock
+    if: |
+      always() &&
+      (needs.refresh-lock.result == 'success' || needs.refresh-lock.result == 'skipped')
+    runs-on: ubuntu-slim
+    strategy:
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+        dbt-core: ["15", "16", "17", "110", "111"]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository:
+            ${{ github.event.pull_request.head.repo.full_name ||
+            github.repository }}
+      - name: Install uv and set the Python version
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           uv sync --locked --only-dev
@@ -77,6 +90,10 @@ jobs:
           uv run tox -e py${PYTHON_VERSION}-dbt${{ matrix.dbt-core }}
 
   lint:
+    needs: refresh-lock
+    if: |
+      always() &&
+      (needs.refresh-lock.result == 'success' || needs.refresh-lock.result == 'skipped')
     runs-on: ubuntu-slim
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,15 +46,23 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.actor == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token || github.token }}
         run: |
           uv lock
-          if ! git diff --quiet -- uv.lock; then
-            git config user.name "uv-lock-bot[bot]"
-            git config user.email "uv-lock-bot[bot]@users.noreply.github.com"
-            git add uv.lock
-            git commit -m "chore: refresh uv.lock"
-            git push || echo "push skipped (no perms)"
+          if git diff --quiet -- uv.lock; then
+            exit 0
           fi
+
+          REPO="${{ github.repository }}"
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          SHA=$(gh api "/repos/$REPO/contents/uv.lock?ref=$BRANCH" --jq .sha)
+
+          gh api --method PUT "/repos/$REPO/contents/uv.lock" \
+            -f message="chore: refresh uv.lock" \
+            -f content="$(base64 -w0 uv.lock)" \
+            -f branch="$BRANCH" \
+            -f sha="$SHA"
       - name: Install dependencies
         run: |
           uv sync --locked --only-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
       always() &&
       (needs.refresh-lock.result == 'success' || needs.refresh-lock.result == 'skipped')
     runs-on: ubuntu-slim
-
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install uv and set the Python version


### PR DESCRIPTION
Swaps the `git commit`/`git push` step for a `gh api` Contents API call, so the Dependabot lockfile-refresh commit shows as Verified.
