### PR TITLE
Switch dependabot package-ecosystem from pip -> uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,61 +9,8 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  refresh-lock:
-    runs-on: ubuntu-slim
-    if: |
-      github.event_name == 'pull_request' &&
-      github.actor == 'dependabot[bot]'
-    steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: write
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          python-version: "3.13"
-      - name: Refresh uv.lock
-        env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
-          REPO: ${{ github.repository }}
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "App token unavailable, refusing to refresh uv.lock as a different identity" >&2
-            exit 1
-          fi
-
-          uv lock
-          if git diff --quiet -- uv.lock; then
-            exit 0
-          fi
-
-          SHA=$(gh api "/repos/$REPO/contents/uv.lock?ref=$BRANCH" --jq .sha)
-
-          gh api --method PUT "/repos/$REPO/contents/uv.lock" \
-            -f message="chore: refresh uv.lock" \
-            -f content="$(base64 -w0 uv.lock)" \
-            -f branch="$BRANCH" \
-            -f sha="$SHA"
-
   build:
-    needs: refresh-lock
-    if: |
-      always() &&
-      (needs.refresh-lock.result == 'success' || needs.refresh-lock.result == 'skipped')
     runs-on: ubuntu-slim
     strategy:
       matrix:
@@ -90,10 +37,6 @@ jobs:
           uv run tox -e py${PYTHON_VERSION}-dbt${{ matrix.dbt-core }}
 
   lint:
-    needs: refresh-lock
-    if: |
-      always() &&
-      (needs.refresh-lock.result == 'success' || needs.refresh-lock.result == 'skipped')
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
The goal of this change is to enable dependabot to update dependencies in `pyproject.toml` and updating `uv.lock`.

This was previously handled by the `uv-lock-bot` and more recently by the `refresh-lock` GHA step. However, this approach is much simpler.